### PR TITLE
Use existing decoder instances for opening images

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -107,8 +107,8 @@ jobs:
       condition: and(succeeded(), ne(variables.CACHE_RESTORED, 'true'))
     - bash: |
         set -ex
-        vcpkg install qtbase[concurrent,core,dbus,default-features,doubleconversion,gui,icu,jpeg,pcre2,png,testlib,widgets]:$(platform)-windows qtsvg:$(platform)-windows
-        vcpkg install qtbase[concurrent,core,dbus,default-features,doubleconversion,gui,icu,jpeg,pcre2,png,testlib,widgets]:$(platform)-windows-static qtsvg:$(platform)-windows-static
+        vcpkg install qtbase[concurrent,core,default-features,doubleconversion,gui,harfbuzz,icu,jpeg,pcre2,png,testlib,widgets]:$(platform)-windows qtsvg:$(platform)-windows
+        vcpkg install qtbase[concurrent,core,default-features,doubleconversion,gui,harfbuzz,icu,jpeg,pcre2,png,testlib,widgets]:$(platform)-windows-static qtsvg:$(platform)-windows-static
       displayName: 'vcpkg build Qt6'
       condition: and(succeeded(), ne(variables.CACHE_RESTORED, 'true'))
     - bash: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -125,7 +125,7 @@ jobs:
           pathtoPublish: $(VCPKG_INSTALLATION_ROOT)/installed
           artifactName: vcpkg-deps-$(platform)-$(poo)
       condition: or(succeeded(), failed())
-      enabled: true
+      enabled: false
     - bash: |
         set -ex
         mkdir build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -75,7 +75,7 @@ jobs:
       displayName: "Cache vcpkg's packages"
       condition: and(not(in(variables['Build.Reason'], 'Schedule')), ${{ parameters.useCache }})
       inputs:
-        key: $(VCPKG_REVISION) | "$(platform)" | "$(poo)" | "withstaticlibs2"
+        key: $(VCPKG_REVISION) | "$(platform)" | "$(poo)" | "withstaticlibs3"
         path: '$(VCPKG_INSTALLATION_ROOT)\installed'
         cacheHitVar: CACHE_RESTORED
     - bash: |
@@ -107,8 +107,8 @@ jobs:
       condition: and(succeeded(), ne(variables.CACHE_RESTORED, 'true'))
     - bash: |
         set -ex
-        vcpkg install qtbase:$(platform)-windows qtsvg:$(platform)-windows
-        vcpkg install qtbase:$(platform)-windows-static qtsvg:$(platform)-windows-static
+        vcpkg install qtbase[concurrent,core,dbus,default-features,doubleconversion,gui,icu,jpeg,pcre2,png,testlib,widgets]:$(platform)-windows qtsvg:$(platform)-windows
+        vcpkg install qtbase[concurrent,core,dbus,default-features,doubleconversion,gui,icu,jpeg,pcre2,png,testlib,widgets]:$(platform)-windows-static qtsvg:$(platform)-windows-static
       displayName: 'vcpkg build Qt6'
       condition: and(succeeded(), ne(variables.CACHE_RESTORED, 'true'))
     - bash: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -134,8 +134,8 @@ jobs:
         set -ex
         mkdir build
         cd build
-        export PKG_CONFIG_PATH=$VCPKG_INSTALLATION_ROOT/installed/$(platform)-windows-static/debug/lib/pkgconfig
-        cmake -G "$(generator)" -A "$(cmake_platform)" -T "$(toolset)" -DCMAKE_BUILD_TYPE=$(configuration) -DVCPKG_TARGET_TRIPLET=$(platform)-windows-static -DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake -DCMAKE_INSTALL_PREFIX=$VCPKG_INSTALLATION_ROOT/installed/$(platform)-windows-static -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDebug -DCMAKE_VERBOSE_MAKEFILE=1 ..
+        export PKG_CONFIG_PATH=$VCPKG_INSTALLATION_ROOT/installed/$(platform)-windows-static/lib/pkgconfig
+        cmake -G "$(generator)" -A "$(cmake_platform)" -T "$(toolset)" -DCMAKE_BUILD_TYPE=$(configuration) -DVCPKG_TARGET_TRIPLET=$(platform)-windows-static -DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake -DCMAKE_INSTALL_PREFIX=$VCPKG_INSTALLATION_ROOT/installed/$(platform)-windows-static -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded -DCMAKE_VERBOSE_MAKEFILE=1 ..
         cmake --build . --config $(configuration) --parallel 3 --target anpv
       displayName: 'Compile static ANPV'
     - task: CopyFiles@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,6 +53,10 @@ jobs:
     cancelTimeoutInMinutes: 2
     strategy:
       matrix:
+        Win10:
+          toolset: 'v142'
+          generator: 'Visual Studio 16 2019'
+          poo: 'windows-2019'
         Win11:
           toolset: 'v143'
           generator: 'Visual Studio 17 2022'
@@ -60,7 +64,7 @@ jobs:
     pool:
       vmImage: $(poo)
     variables:
-      configuration: 'Debug'
+      configuration: 'Release'
       VCPKG_REVISION: 'b86c0c35b88e2bf3557ff49dc831689c2f085090'
       platform: 'x64'
       cmake_platform: 'x64'
@@ -137,7 +141,7 @@ jobs:
     - task: CopyFiles@2
       continueOnError: true
       inputs:
-        SourceFolder: 'build'
+        SourceFolder: 'build\$(configuration)'
         Contents: '**'
         TargetFolder: '$(Build.ArtifactStagingDirectory)'
     - task: PublishBuildArtifacts@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,10 +53,6 @@ jobs:
     cancelTimeoutInMinutes: 2
     strategy:
       matrix:
-        Win10:
-          toolset: 'v142'
-          generator: 'Visual Studio 16 2019'
-          poo: 'windows-2019'
         Win11:
           toolset: 'v143'
           generator: 'Visual Studio 17 2022'
@@ -64,7 +60,7 @@ jobs:
     pool:
       vmImage: $(poo)
     variables:
-      configuration: 'Release'
+      configuration: 'Debug'
       VCPKG_REVISION: 'b86c0c35b88e2bf3557ff49dc831689c2f085090'
       platform: 'x64'
       cmake_platform: 'x64'
@@ -129,7 +125,7 @@ jobs:
           pathtoPublish: $(VCPKG_INSTALLATION_ROOT)/installed
           artifactName: vcpkg-deps-$(platform)-$(poo)
       condition: or(succeeded(), failed())
-      enabled: false
+      enabled: true
     - bash: |
         set -ex
         mkdir build
@@ -141,7 +137,7 @@ jobs:
     - task: CopyFiles@2
       continueOnError: true
       inputs:
-        SourceFolder: 'build\$(configuration)'
+        SourceFolder: 'build'
         Contents: '**'
         TargetFolder: '$(Build.ArtifactStagingDirectory)'
     - task: PublishBuildArtifacts@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -130,8 +130,8 @@ jobs:
         set -ex
         mkdir build
         cd build
-        export PKG_CONFIG_PATH=$VCPKG_INSTALLATION_ROOT/installed/$(platform)-windows-static/lib/pkgconfig
-        cmake -G "$(generator)" -A "$(cmake_platform)" -T "$(toolset)" -DCMAKE_BUILD_TYPE=$(configuration) -DVCPKG_TARGET_TRIPLET=$(platform)-windows-static -DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake -DCMAKE_INSTALL_PREFIX=$VCPKG_INSTALLATION_ROOT/installed/$(platform)-windows-static -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded -DCMAKE_VERBOSE_MAKEFILE=1 ..
+        export PKG_CONFIG_PATH=$VCPKG_INSTALLATION_ROOT/installed/$(platform)-windows-static/debug/lib/pkgconfig
+        cmake -G "$(generator)" -A "$(cmake_platform)" -T "$(toolset)" -DCMAKE_BUILD_TYPE=$(configuration) -DVCPKG_TARGET_TRIPLET=$(platform)-windows-static -DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake -DCMAKE_INSTALL_PREFIX=$VCPKG_INSTALLATION_ROOT/installed/$(platform)-windows-static -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDebug -DCMAKE_VERBOSE_MAKEFILE=1 ..
         cmake --build . --config $(configuration) --parallel 3 --target anpv
       displayName: 'Compile static ANPV'
     - task: CopyFiles@2

--- a/main.cpp
+++ b/main.cpp
@@ -95,6 +95,14 @@ int main(int argc, char *argv[])
     break;
     }
     
-    int r = app.exec();
-    return r;
+    try
+    {
+        int r = app.exec();
+        return r;
+    }
+    catch(const std::exception& e)
+    {
+        QMessageBox::critical(nullptr, "Unhandled Exception", e.what());
+    }
+    return -1;
 }

--- a/main.cpp
+++ b/main.cpp
@@ -2,6 +2,7 @@
 #include "DecoderFactory.hpp"
 #include "Image.hpp"
 #include "Formatter.hpp"
+#include "types.hpp"
 
 #include <QApplication>
 #include <QGraphicsScene>
@@ -81,10 +82,10 @@ int main(int argc, char *argv[])
     }
     default:
     {
-        QList<QSharedPointer<Image>> files;
+        QList<Entry_t> files;
         for(int i=1; i<argc;i++)
         {
-            files.emplace_back(DecoderFactory::globalInstance()->makeImage(QFileInfo(QString(argv[i]))));
+            files.emplace_back(std::make_pair(DecoderFactory::globalInstance()->makeImage(QFileInfo(QString(argv[i]))), nullptr));
         }
         
         splash.showMessage("Starting the image decoding task...");

--- a/src/decoders/SmartImageDecoder.cpp
+++ b/src/decoders/SmartImageDecoder.cpp
@@ -230,6 +230,8 @@ void SmartImageDecoder::cancelOrTake(QFuture<DecodingState> taskFuture)
         {
             // current decoder was taken from the pool and will therefore never emit finished event, even though some clients are relying on this...
             d->promise->start();
+            this->setDecodingState(DecodingState::Cancelled);
+            d->promise->addResult(d->decodingState());
             d->promise->finish();
         }
     }

--- a/src/decoders/SmartImageDecoder.hpp
+++ b/src/decoders/SmartImageDecoder.hpp
@@ -39,11 +39,12 @@ public:
     // they are virtual for the purpose of unit testing.
     virtual void open();
     virtual void init();
-    virtual void decode(DecodingState targetState, QSize desiredResolution = QSize(), QRect roiRect = QRect());
     virtual void close();
+    void decode(DecodingState targetState, QSize desiredResolution = QSize(), QRect roiRect = QRect());
     void reset();
     
     void run() override;
+    void cancelOrTake(QFuture<DecodingState> taskFuture);
     void releaseFullImage();
 
 protected:

--- a/src/logic/ANPV.cpp
+++ b/src/logic/ANPV.cpp
@@ -178,11 +178,11 @@ struct ANPV::Impl
                 {
                     QList<QString> files = q->getExistingFile(QApplication::focusWidget(), lastOpenImageDir);
                     
-                    QList<QSharedPointer<Image>> images;
+                    QList<Entry_t> images;
                     images.reserve(files.size());
                     for(auto& f : files)
                     {
-                        images.emplace_back(DecoderFactory::globalInstance()->makeImage(QFileInfo(f)));
+                        images.emplace_back(std::make_pair(DecoderFactory::globalInstance()->makeImage(QFileInfo(f)), nullptr));
                     }
                     q->openImages(images);
                 });
@@ -577,7 +577,7 @@ void ANPV::showThumbnailView(QSplashScreen* splash)
     splash->finish(d->mainWindow.get());
 }
 
-void ANPV::openImages(const QList<QSharedPointer<Image>>& image)
+void ANPV::openImages(const QList<Entry_t>& image)
 {
     xThreadGuard g(this);
     if(image.isEmpty())

--- a/src/logic/ANPV.hpp
+++ b/src/logic/ANPV.hpp
@@ -10,6 +10,7 @@
 
 #include "DecodingState.hpp"
 #include "SortedImageModel.hpp"
+#include "types.hpp"
 
 class MoveFileCommand;
 class QSplashScreen;
@@ -25,24 +26,6 @@ class QAction;
 
 template<typename T>
 class QFuture;
-
-enum class ViewMode : int
-{
-    Unknown,
-    None,
-    Fit,
-};
-
-using ViewFlags_t = unsigned int;
-enum class ViewFlag : ViewFlags_t
-{
-    None = 0,
-    CombineRawJpg = 1 << 0,
-    ShowAfPoints =  1 << 1,
-    RespectExifOrientation = 1 << 2,
-    CenterAf = 1 << 3,
-    ShowScrollBars = 1 << 4,
-};
 
 
 class ANPV : public QObject
@@ -61,7 +44,7 @@ public:
     ANPV(QSplashScreen *splash);
     ~ANPV() override;
 
-    void openImages(const QList<QSharedPointer<Image>>&);
+    void openImages(const QList<Entry_t>&);
     void showThumbnailView();
     void showThumbnailView(QSplashScreen*);
     

--- a/src/logic/ANPV.hpp
+++ b/src/logic/ANPV.hpp
@@ -95,8 +95,6 @@ signals:
     
 public slots:
     void about();
-//     void loadImage(QFileInfo str);
-//     void loadImage(QSharedPointer<SmartImageDecoder> dec);
     
 private:
     struct Impl;

--- a/src/logic/types.hpp
+++ b/src/logic/types.hpp
@@ -1,0 +1,29 @@
+
+#pragma once
+
+#include <utility>
+
+#include <QSharedPointer>
+
+enum class ViewMode : int
+{
+    Unknown,
+    None,
+    Fit,
+};
+
+using ViewFlags_t = unsigned int;
+enum class ViewFlag : ViewFlags_t
+{
+    None = 0,
+    CombineRawJpg = 1 << 0,
+    ShowAfPoints =  1 << 1,
+    RespectExifOrientation = 1 << 2,
+    CenterAf = 1 << 3,
+    ShowScrollBars = 1 << 4,
+};
+
+class Image;
+class SmartImageDecoder;
+using Entry_t = std::pair<QSharedPointer<Image>, QSharedPointer<SmartImageDecoder>>;
+

--- a/src/models/SortedImageModel.cpp
+++ b/src/models/SortedImageModel.cpp
@@ -41,7 +41,6 @@ struct SortedImageModel::Impl
     
     QFileSystemWatcher* watcher = nullptr;
     QDir currentDir;
-    using Entry_t = std::pair<QSharedPointer<Image>, QSharedPointer<SmartImageDecoder>>;
     std::vector<Entry_t> entries;
     
     // keep track of all image decoding tasks we spawn in the background, guarded by mutex, because accessed by UI thread and directory worker thread
@@ -277,12 +276,12 @@ struct SortedImageModel::Impl
     template<Column SortCol>
     static bool topLevelSortFunction(const Entry_t& l, const Entry_t& r)
     {
-        const QFileInfo& linfo = std::get<0>(l)->fileInfo();
-        const QFileInfo& rinfo = std::get<0>(r)->fileInfo();
+        const QFileInfo& linfo = SortedImageModel::image(l)->fileInfo();
+        const QFileInfo& rinfo = SortedImageModel::image(r)->fileInfo();
 
         bool leftIsBeforeRight =
             (linfo.isDir() && (!rinfo.isDir() || compareFileName(linfo, rinfo))) ||
-            (!rinfo.isDir() && sortColumnPredicateLeftBeforeRight<SortCol>(std::get<0>(l), linfo, std::get<0>(r), rinfo));
+            (!rinfo.isDir() && sortColumnPredicateLeftBeforeRight<SortCol>(SortedImageModel::image(l), linfo, SortedImageModel::image(r), rinfo));
         
         return leftIsBeforeRight;
     }
@@ -341,14 +340,14 @@ struct SortedImageModel::Impl
         
         // find the beginning to reverse
         auto itBegin = std::begin(entries);
-        while(itBegin != std::end(entries) && !std::get<0>(*itBegin)->hasDecoder())
+        while(itBegin != std::end(entries) && !SortedImageModel::image(*itBegin)->hasDecoder())
         {
             ++itBegin;
         }
         
         // find end to reverse
         auto itEnd = std::end(entries) - 1;
-        while(itEnd != std::begin(entries) && !std::get<0>(*itEnd)->hasDecoder())
+        while(itEnd != std::begin(entries) && !SortedImageModel::image(*itEnd)->hasDecoder())
         {
             --itEnd;
         }
@@ -542,7 +541,7 @@ struct SortedImageModel::Impl
         q->beginResetModel();
         for(auto it = entries.begin(); it != entries.end();)
         {
-            QFileInfo eInfo = std::get<0>(*it)->fileInfo();
+            QFileInfo eInfo = SortedImageModel::image(*it)->fileInfo();
             auto result = std::find_if(fileInfoList.begin(),
                                     fileInfoList.end(),
                                     [=](QFileInfo& other)
@@ -758,9 +757,9 @@ void SortedImageModel::decodeAllImages(DecodingState state, int imageHeight)
     d->waitForDirectoryWorker();
     d->cancelAllBackgroundTasks();
 
-    for(Impl::Entry_t& e : d->entries)
+    for(Entry_t& e : d->entries)
     {
-        QSharedPointer<SmartImageDecoder>& decoder = std::get<1>(e);
+        const QSharedPointer<SmartImageDecoder>& decoder = SortedImageModel::decoder(e);
         if(decoder)
         {
             bool taken = QThreadPool::globalInstance()->tryTake(decoder.get());
@@ -779,27 +778,27 @@ void SortedImageModel::decodeAllImages(DecodingState state, int imageHeight)
     }
 }
 
-QSharedPointer<Image> SortedImageModel::image(const QModelIndex& idx) const
+Entry_t SortedImageModel::entry(const QModelIndex& idx) const
 {
-    return std::get<0>(d->entry(idx));
+    return d->entry(idx);
 }
 
-QSharedPointer<Image> SortedImageModel::image(unsigned int row) const
+Entry_t SortedImageModel::entry(unsigned int row) const
 {
-    return std::get<0>(d->entry(row));
+    return d->entry(row);
 }
 
-QSharedPointer<SmartImageDecoder> SortedImageModel::decoder(const QModelIndex& idx) const
+const QSharedPointer<Image>& SortedImageModel::image(const Entry_t& e)
 {
-    return std::get<1>(d->entry(idx));
+    return std::get<0>(e);
 }
 
-QSharedPointer<SmartImageDecoder> SortedImageModel::decoder(unsigned int row) const
+const QSharedPointer<SmartImageDecoder>& SortedImageModel::decoder(const Entry_t& e)
 {
-    return std::get<1>(d->entry(row));
+    return std::get<1>(e);
 }
 
-QSharedPointer<Image> SortedImageModel::goTo(const QSharedPointer<Image>& img, int stepsFromCurrent)
+Entry_t SortedImageModel::goTo(const QSharedPointer<Image>& img, int stepsFromCurrent)
 {
     xThreadGuard g(this);
     d->waitForDirectoryWorker();
@@ -808,33 +807,33 @@ QSharedPointer<Image> SortedImageModel::goTo(const QSharedPointer<Image>& img, i
     
     auto result = std::find_if(d->entries.begin(),
                                d->entries.end(),
-                            [&](const Impl::Entry_t& other)
-                            { return std::get<0>(other) == img; });
+                            [&](const Entry_t& other)
+                            { return this->image(other) == img; });
     
     if(result == d->entries.end())
     {
         qInfo() << "requested image not found";
-        return nullptr;
+        return {};
     }
     
     int size = d->entries.size();
     int idx = std::distance(d->entries.begin(), result);
-    QSharedPointer<Image> e;
+    Entry_t e;
     do
     {
         if(idx >= size - step || // idx + step >= size
             idx < -step) // idx + step < 0
         {
-            return nullptr;
+            return {};
         }
         
         idx += step;
         
-        e = this->image(idx);
-        QFileInfo eInfo = e->fileInfo();
+        e = this->entry(idx);
+        QFileInfo eInfo = this->image(e)->fileInfo();
         bool shouldSkip = eInfo.suffix() == "bak";
-        shouldSkip |= d->hideRawIfNonRawAvailable(e);
-        if(e->hasDecoder() && !shouldSkip)
+        shouldSkip |= d->hideRawIfNonRawAvailable(this->image(e));
+        if(this->image(e)->hasDecoder() && !shouldSkip)
         {
             stepsFromCurrent -= step;
         }
@@ -856,7 +855,7 @@ Qt::ItemFlags SortedImageModel::flags(const QModelIndex &index) const
     
     if(index.isValid() && (d->cachedViewFlags & static_cast<ViewFlags_t>(ViewFlag::CombineRawJpg)) != 0)
     {
-        QSharedPointer<Image> e = this->image(index);
+        QSharedPointer<Image> e = this->image(this->entry(index));
         if(e && d->hideRawIfNonRawAvailable(e))
         {
             f &= ~(Qt::ItemIsSelectable|Qt::ItemIsEnabled);
@@ -893,7 +892,7 @@ QVariant SortedImageModel::data(const QModelIndex& index, int role) const
     if (index.isValid())
     {
         d->waitForDirectoryWorker();
-        QSharedPointer<Image> e = this->image(index.row());
+        QSharedPointer<Image> e = this->image(this->entry(index));
         const QFileInfo& fileInfo = e->fileInfo();
 
         switch (role)
@@ -1014,8 +1013,8 @@ QModelIndex SortedImageModel::index(const Image* img)
     d->waitForDirectoryWorker();
     auto result = std::find_if(d->entries.begin(),
                                d->entries.end(),
-                            [&](const Impl::Entry_t& other)
-                            { return std::get<0>(other).data() == img; });
+                            [&](const Entry_t& other)
+                            { return this->image(other).data() == img; });
     
     if(result == d->entries.end())
     {
@@ -1033,7 +1032,7 @@ QFileInfo SortedImageModel::fileInfo(const QModelIndex &index) const
     if(index.isValid())
     {
         d->waitForDirectoryWorker();
-        return this->image(index.row())->fileInfo();
+        return this->image(this->entry(index))->fileInfo();
     }
     
     return QFileInfo();

--- a/src/models/SortedImageModel.hpp
+++ b/src/models/SortedImageModel.hpp
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "DecodingState.hpp"
+#include "types.hpp"
 
 #include <QAbstractListModel>
 #include <QRunnable>
@@ -38,6 +39,8 @@ public:
         CameraModel,
         Count // must be last!
     };
+    static const QSharedPointer<Image>& image(const Entry_t& e);
+    static const QSharedPointer<SmartImageDecoder>& decoder(const Entry_t& e);
 
     SortedImageModel(QObject* parent = nullptr);
     ~SortedImageModel() override;
@@ -50,11 +53,9 @@ public:
     QModelIndex index(const QSharedPointer<Image>& img);
     QModelIndex index(const Image* img);
     QFileInfo fileInfo(const QModelIndex& idx) const;
-    QSharedPointer<Image> goTo(const QSharedPointer<Image>& img, int stepsFromCurrent);
-    QSharedPointer<Image> image(const QModelIndex& idx) const;
-    QSharedPointer<Image> image(unsigned int row) const;
-    QSharedPointer<SmartImageDecoder> decoder(const QModelIndex& idx) const;
-    QSharedPointer<SmartImageDecoder> decoder(unsigned int row) const;
+    Entry_t goTo(const QSharedPointer<Image>& img, int stepsFromCurrent);
+    Entry_t entry(const QModelIndex& idx) const;
+    Entry_t entry(unsigned int row) const;
 
     void sort(Column column);
     void sort(Qt::SortOrder order);

--- a/src/widgets/DocumentView.cpp
+++ b/src/widgets/DocumentView.cpp
@@ -85,20 +85,11 @@ struct DocumentView::Impl
     
     void clearScene()
     {
-        bool isFinished = taskFuture.isFinished();
-        bool taken = QThreadPool::globalInstance()->tryTake(currentImageDecoder.get());
-        if(!isFinished)
-        {
-            if(!taken)
-            {
-                taskFuture.cancel();
-                taskFuture.waitForFinished();
-            }
-            taskFuture.setFuture(QFuture<DecodingState>());
-        }
-        
         if(currentImageDecoder)
         {
+            currentImageDecoder->cancelOrTake(taskFuture.future());
+            taskFuture.waitForFinished();
+            currentImageDecoder->releaseFullImage();
             currentImageDecoder->image()->disconnect(p);
             currentImageDecoder.reset();
             latestDecodingState = DecodingState::Ready;

--- a/src/widgets/DocumentView.cpp
+++ b/src/widgets/DocumentView.cpp
@@ -643,7 +643,7 @@ void DocumentView::onImageRefinement(Image* img, QImage image)
 void DocumentView::onDecodingStateChanged(Image* img, quint32 newState, quint32 oldState)
 {
     auto& dec = d->currentImageDecoder;
-    if(img != dec->image().data())
+    if(dec && img != dec->image().data())
     {
         // ignore events from a previous decoder that might still be running in the background
         return;

--- a/src/widgets/DocumentView.cpp
+++ b/src/widgets/DocumentView.cpp
@@ -100,7 +100,6 @@ struct DocumentView::Impl
         if(currentImageDecoder)
         {
             currentImageDecoder->image()->disconnect(p);
-            currentImageDecoder->reset();
             currentImageDecoder.reset();
             latestDecodingState = DecodingState::Ready;
         }

--- a/src/widgets/DocumentView.hpp
+++ b/src/widgets/DocumentView.hpp
@@ -1,6 +1,7 @@
 
 #pragma once
 
+#include "types.hpp"
 #include <memory>
 #include <QGraphicsView>
 #include <QImage>
@@ -29,9 +30,10 @@ public:
 
     void setModel(QSharedPointer<SortedImageModel>);
     QFileInfo currentFile();
+    void loadImage(const Entry_t& e);
     void loadImage(QSharedPointer<Image> image);
     void loadImage(QString url);
-    void loadImage(std::unique_ptr<SmartImageDecoder>&& dec);
+    void loadImage(const QSharedPointer<SmartImageDecoder>& dec);
     
 public slots:
     void zoomIn();

--- a/src/widgets/MainWindow.cpp
+++ b/src/widgets/MainWindow.cpp
@@ -429,9 +429,9 @@ struct MainWindow::Impl
         {
             size_t count = imgs.size();
             size_t size = 0;
-            for(QSharedPointer<Image>& i : imgs)
+            for(Entry_t& e : imgs)
             {
-                size += i->fileInfo().size();
+                size += SortedImageModel::image(e)->fileInfo().size();
             }
             
             QString text = QString(

--- a/src/widgets/MultiDocumentView.cpp
+++ b/src/widgets/MultiDocumentView.cpp
@@ -2,6 +2,7 @@
 
 #include "DocumentView.hpp"
 #include "Image.hpp"
+#include "SortedImageModel.hpp"
 
 #include <QTabWidget>
 #include <QGuiApplication>
@@ -77,14 +78,14 @@ MultiDocumentView::MultiDocumentView(QMainWindow *parent)
 
 MultiDocumentView::~MultiDocumentView() = default;
 
-void MultiDocumentView::addImages(const QList<QSharedPointer<Image>>& image, QSharedPointer<SortedImageModel> model)
+void MultiDocumentView::addImages(const QList<Entry_t>& image, QSharedPointer<SortedImageModel> model)
 {
     if(image.empty())
     {
         return;
     }
     
-    for(auto& i : image)
+    for(auto& e : image)
     {
         DocumentView* dv = new DocumentView(d->tw);
 
@@ -106,7 +107,16 @@ void MultiDocumentView::addImages(const QList<QSharedPointer<Image>>& image, QSh
 
         d->tw->addTab(dv, "");
         dv->setModel(model);
-        dv->loadImage(i);
+        auto& dec = SortedImageModel::decoder(e);
+        auto& img = SortedImageModel::image(e);
+        if(dec)
+        {
+            dv->loadImage(dec);
+        }
+        else
+        {
+            dv->loadImage(img);
+        }
         dv->setAttribute(Qt::WA_DeleteOnClose);
     }
     d->tw->currentWidget()->setFocus(Qt::PopupFocusReason);

--- a/src/widgets/MultiDocumentView.hpp
+++ b/src/widgets/MultiDocumentView.hpp
@@ -1,6 +1,7 @@
 
 #pragma once
 
+#include "types.hpp"
 #include <memory>
 #include <QMainWindow>
 #include <QList>
@@ -17,7 +18,7 @@ public:
     MultiDocumentView(QMainWindow *parent);
     ~MultiDocumentView() override;
 
-    void addImages(const QList<QSharedPointer<Image>>& image, QSharedPointer<SortedImageModel> model);
+    void addImages(const QList<Entry_t>& image, QSharedPointer<SortedImageModel> model);
     void keyPressEvent(QKeyEvent *event) override;
     void closeEvent(QCloseEvent *event) override;
 

--- a/src/widgets/ThumbnailListView.hpp
+++ b/src/widgets/ThumbnailListView.hpp
@@ -1,6 +1,8 @@
 
 #pragma once
 
+#include "types.hpp"
+
 #include <QListView>
 #include <QString>
 #include <QSharedPointer>
@@ -26,8 +28,8 @@ public:
     void setModel(QAbstractItemModel *model) override;
 
     void moveSelectedFiles(QString&& destination);
-    QList<QSharedPointer<Image>> selectedImages();
-    QList<QSharedPointer<Image>> selectedImages(const QModelIndexList& selectedIdx);
+    QList<Entry_t> selectedImages();
+    QList<Entry_t> selectedImages(const QModelIndexList& selectedIdx);
         
 protected:
     void wheelEvent(QWheelEvent *event) override;

--- a/test/DecoderTest.cpp
+++ b/test/DecoderTest.cpp
@@ -259,8 +259,8 @@ void DecoderTest::testAccessingDecoderWhileStillDecodingOngoing()
     
     QFuture<DecodingState> fut = dec->decodeAsync(DecodingState::Metadata, Priority::Normal);
     
-    QVERIFY(fut.isStarted());
     QThread::msleep(1);
+    QVERIFY(fut.isStarted());
     QVERIFY(fut.isRunning());
     
     dec->reset();

--- a/test/DecoderTest.cpp
+++ b/test/DecoderTest.cpp
@@ -15,6 +15,9 @@
 #include <QFuture>
 #include <QFutureWatcher>
 
+#include <thread>
+#include <chrono>
+
 QTEST_MAIN(DecoderTest)
 #include "DecoderTest.moc"
 
@@ -27,6 +30,7 @@ class ImageDecoderUnderTest : public SmartImageDecoder
     friend class DecoderTest;
     bool decodeHeaderFail = false;
     bool decodingLoopFail = false;
+    int sleepMs = 0;
 public:
     void setDecodeHeaderFail(bool b)
     {
@@ -36,6 +40,11 @@ public:
     void setDecodingLoopFail(bool b)
     {
         this->decodingLoopFail = b;
+    }
+    
+    void setSleep(int ms)
+    {
+        this->sleepMs = ms;
     }
     
     ImageDecoderUnderTest(QSharedPointer<Image> image) : SmartImageDecoder(image)
@@ -50,6 +59,7 @@ protected:
 
     QImage decodingLoop(QSize desiredResolution, QRect roiRect) override
     {
+        std::this_thread::sleep_for(std::chrono::milliseconds(this->sleepMs));
         if(this->decodingLoopFail)
             throw std::runtime_error(errDec);
         

--- a/test/DecoderTest.hpp
+++ b/test/DecoderTest.hpp
@@ -12,5 +12,6 @@ private slots:
     void testInitialize();
     void testResettingWhileDecoding();
     void testFinishBeforeSettingFutureWatcher();
+    void testAccessingDecoderWhileStillDecodingOngoing();
     void testTakeDecoderFromThreadPoolBeforeDecodingCouldBeStarted();
 };


### PR DESCRIPTION
The SortedImageModel creates tons of decoders that run in the background to retrieve first metadata from the images. If the user opens an image which is currently being decoded, yet another decoder is created so that two decoders access the same image in the end. This is not good.

Instead, cache the available decoders and pass them on to the DocumentView. This way we only need to make sure that the decoder class itself can be used by many clients. This has been done with this PR.