### PR TITLE
Support hard linking files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,6 +149,8 @@ src/decoders/SmartTiffDecoder.hpp
 src/logic/ExifWrapper.cpp
 src/logic/ExifWrapper.hpp
 src/logic/Formatter.hpp
+src/logic/HardLinkFileCommand.cpp
+src/logic/HardLinkFileCommand.hpp
 src/logic/Image.cpp
 src/logic/Image.hpp
 src/logic/MoonPhase.cpp

--- a/src/logic/ANPV.cpp
+++ b/src/logic/ANPV.cpp
@@ -634,7 +634,6 @@ QUndoStack* ANPV::undoStack()
     return d->undoStack;
 }
 
-
 void ANPV::hardLinkFiles(QList<QString>&& fileNames, QString&& source, QString&& destination)
 {
     xThreadGuard g(this);
@@ -646,7 +645,7 @@ void ANPV::hardLinkFiles(QList<QString>&& fileNames, QString&& source, QString&&
                     "Hardlink operation failed",
                     "Some files could not be hardlinked to the destination folder. See details below.",
                     QMessageBox::Ok,
-                    d->mainWindow.get());
+                    QApplication::focusWidget());
         
         QString details;
         for(int i=0; i<failedFilesWithReason.size(); i++)
@@ -679,7 +678,7 @@ void ANPV::moveFiles(QList<QString>&& fileNames, QString&& source, QString&& des
                     "Move operation failed",
                     "Some files could not be moved to the destination folder. See details below.",
                     QMessageBox::Ok,
-                    d->mainWindow.get());
+                    QApplication::focusWidget());
         
         QString details;
         for(int i=0; i<failedFilesWithReason.size(); i++)

--- a/src/logic/ANPV.cpp
+++ b/src/logic/ANPV.cpp
@@ -42,6 +42,7 @@
 #include "Formatter.hpp"
 #include "SortedImageModel.hpp"
 #include "SmartImageDecoder.hpp"
+#include "HardLinkFileCommand.hpp"
 #include "MoveFileCommand.hpp"
 #include "FileOperationConfigDialog.hpp"
 #include "CancellableProgressWidget.hpp"
@@ -633,12 +634,46 @@ QUndoStack* ANPV::undoStack()
     return d->undoStack;
 }
 
-void ANPV::moveFiles(QList<QString>&& files, QString&& source, QString&& destination)
+
+void ANPV::hardLinkFiles(QList<QString>&& fileNames, QString&& source, QString&& destination)
 {
     xThreadGuard g(this);
-    MoveFileCommand* cmd = new MoveFileCommand(std::move(files), std::move(source), std::move(destination));
+    HardLinkFileCommand* cmd = new HardLinkFileCommand(std::move(fileNames), std::move(source), std::move(destination));
     
-    connect(cmd, &MoveFileCommand::moveFailed, this, [&](QList<QPair<QString, QString>> failedFilesWithReason)
+    connect(cmd, &HardLinkFileCommand::failed, this, [&](QList<QPair<QString, QString>> failedFilesWithReason)
+    {
+        QMessageBox box(QMessageBox::Critical,
+                    "Hardlink operation failed",
+                    "Some files could not be hardlinked to the destination folder. See details below.",
+                    QMessageBox::Ok,
+                    d->mainWindow.get());
+        
+        QString details;
+        for(int i=0; i<failedFilesWithReason.size(); i++)
+        {
+            QPair<QString, QString>& p = failedFilesWithReason[i];
+            details += p.first;
+            
+            if(!p.second.isEmpty())
+            {
+                details += QString(": ") + p.second;
+                details += "\n";
+            }
+        }
+        box.setDetailedText(details);
+        box.setSizePolicy(QSizePolicy::Expanding,QSizePolicy::Expanding);
+        box.exec();
+    });
+    
+    this->undoStack()->push(cmd);
+}
+
+void ANPV::moveFiles(QList<QString>&& fileNames, QString&& source, QString&& destination)
+{
+    xThreadGuard g(this);
+    MoveFileCommand* cmd = new MoveFileCommand(std::move(fileNames), std::move(source), std::move(destination));
+    
+    connect(cmd, &MoveFileCommand::failed, this, [&](QList<QPair<QString, QString>> failedFilesWithReason)
     {
         QMessageBox box(QMessageBox::Critical,
                     "Move operation failed",

--- a/src/logic/ANPV.hpp
+++ b/src/logic/ANPV.hpp
@@ -47,6 +47,8 @@ public:
     void showThumbnailView();
     void showThumbnailView(QSplashScreen*);
     
+    enum FileOperation { Move, Copy, HardLink, Delete };
+    Q_ENUM(FileOperation);
     void hardLinkFiles(QList<QString>&& files, QString&& source, QString&& destination);
     void moveFiles(QList<QString>&& files, QString&& source, QString&& destination);
     

--- a/src/logic/ANPV.hpp
+++ b/src/logic/ANPV.hpp
@@ -47,6 +47,7 @@ public:
     void showThumbnailView();
     void showThumbnailView(QSplashScreen*);
     
+    void hardLinkFiles(QList<QString>&& files, QString&& source, QString&& destination);
     void moveFiles(QList<QString>&& files, QString&& source, QString&& destination);
     
     QAbstractFileIconProvider* iconProvider();

--- a/src/logic/HardLinkFileCommand.cpp
+++ b/src/logic/HardLinkFileCommand.cpp
@@ -1,0 +1,148 @@
+
+#include "HardLinkFileCommand.hpp"
+
+#include <filesystem>
+
+namespace fs = std::filesystem;
+
+HardLinkFileCommand::HardLinkFileCommand(QList<QString>&& ftm, QString&& sourceFolder, QString&& destinationFolder)
+    : filesToLink(std::move(ftm)), sourceFolder(std::move(sourceFolder)), destinationFolder(std::move(destinationFolder))
+    {
+        if(this->filesToLink.size() == 1)
+        {
+            setText(QString("Hardlink %1 to %2")
+            .arg(this->filesToLink[0])
+            .arg(this->destinationFolder));
+        }
+        else
+        {
+            setText(QString("Hardlink %1 files to %2").arg(this->filesToLink.size()).arg(this->destinationFolder));
+        }
+    }
+
+HardLinkFileCommand::~HardLinkFileCommand() = default;
+
+void HardLinkFileCommand::undo()
+{
+    static_assert(sizeof(char16_t) == sizeof(ushort), "ushort must be 2 bytes in size for this code to work");
+    static_assert(alignof(char16_t) == alignof(ushort), "ushort must have same alignment as char16 for this code to work");
+
+    fs::path targetFolder(fs::u8path(this->destinationFolder.toStdString()));
+    targetFolder.make_preferred();
+    
+    QList<QPair<QString, QString>> failedLinks;
+    for(auto it=this->filesToLink.begin(); it != this->filesToLink.end(); )
+    {
+        fs::path destFileName(reinterpret_cast<const char16_t*>(it->utf16()));
+
+        fs::path src(reinterpret_cast<const char16_t*>(this->sourceFolder.utf16()));
+        src.make_preferred();
+        src /= destFileName;
+        
+        fs::path dest(targetFolder);
+        dest /= destFileName;
+        
+        if(!fs::exists(dest))
+        {
+            failedLinks.append(QPair<QString,QString>(*it, QString("Destination no longer exists.")));
+            it = this->filesToLink.erase(it);
+        }
+        else if(!fs::equivalent(src, dest))
+        {
+            failedLinks.append(QPair<QString,QString>(*it, QString("The previously created hardlink is no longer equivalent to the former source file.")));
+            it = this->filesToLink.erase(it);
+        }
+        else
+        {
+            try
+            {
+                fs::remove(dest);
+                ++it;
+            }
+            catch(const fs::filesystem_error& e)
+            {
+                failedLinks.append(QPair<QString,QString>(*it, e.what()));
+                it = this->filesToLink.erase(it);
+            }
+        }
+    }
+    
+    if(!failedLinks.empty())
+    {
+        emit failed(failedLinks);
+    }
+    
+    if(this->filesToLink.empty())
+    {
+        this->setObsolete(true);
+    }
+    else
+    {
+        emit succeeded(this->filesToLink);
+    }
+}
+
+void HardLinkFileCommand::redo()
+{
+    this->doLink(this->sourceFolder, this->destinationFolder);
+}
+
+void HardLinkFileCommand::doLink(const QString& sourceFolder, const QString& destinationFolder)
+{
+    static_assert(sizeof(char16_t) == sizeof(ushort), "ushort must be 2 bytes in size for this code to work");
+    static_assert(alignof(char16_t) == alignof(ushort), "ushort must have same alignment as char16 for this code to work");
+
+    fs::path targetFolder(fs::u8path(destinationFolder.toStdString()));
+    targetFolder.make_preferred();
+    
+    QList<QPair<QString, QString>> failedLinks;
+    for(auto it=this->filesToLink.begin(); it != this->filesToLink.end(); )
+    {
+        fs::path destFileName(reinterpret_cast<const char16_t*>(it->utf16()));
+
+        fs::path src(reinterpret_cast<const char16_t*>(sourceFolder.utf16()));
+        src.make_preferred();
+        src /= destFileName;
+        
+        fs::path dest(targetFolder);
+        dest /= destFileName;
+        
+        if(!fs::exists(src))
+        {
+            failedLinks.append(QPair<QString,QString>(*it, QString("Source vanished.")));
+            it = this->filesToLink.erase(it);
+        }
+        else if(fs::exists(dest))
+        {
+            failedLinks.append(QPair<QString,QString>(*it, QString("Destination already exists.")));
+            it = this->filesToLink.erase(it);
+        }
+        else
+        {
+            try
+            {
+                fs::create_hard_link(src, dest);
+                ++it;
+            }
+            catch(const fs::filesystem_error& e)
+            {
+                failedLinks.append(QPair<QString,QString>(*it, e.what()));
+                it = this->filesToLink.erase(it);
+            }
+        }
+    }
+    
+    if(!failedLinks.empty())
+    {
+        emit failed(failedLinks);
+    }
+    
+    if(this->filesToLink.empty())
+    {
+        this->setObsolete(true);
+    }
+    else
+    {
+        emit succeeded(this->filesToLink);
+    }
+}

--- a/src/logic/HardLinkFileCommand.hpp
+++ b/src/logic/HardLinkFileCommand.hpp
@@ -5,19 +5,19 @@
 #include <QString>
 #include <QList>
 
-class MoveFileCommand : public QObject, public QUndoCommand
+class HardLinkFileCommand : public QObject, public QUndoCommand
 {
     Q_OBJECT
     
-    QList<QString> filesToMove;
+    QList<QString> filesToLink;
     QString sourceFolder;
     QString destinationFolder;
     
-    void doMove(const QString& sourceFolder, const QString& destinationFolder);
+    void doLink(const QString& sourceFolder, const QString& destinationFolder);
     
 public:
-    MoveFileCommand(QList<QString>&& ftm, QString&& sourceFolder, QString&& destinationFolder);
-    ~MoveFileCommand() override;
+    HardLinkFileCommand(QList<QString>&& ftm, QString&& sourceFolder, QString&& destinationFolder);
+    ~HardLinkFileCommand() override;
     
     void undo() override;
 

--- a/src/logic/MoveFileCommand.cpp
+++ b/src/logic/MoveFileCommand.cpp
@@ -79,7 +79,7 @@ void MoveFileCommand::doMove(const QString& sourceFolder, const QString& destina
     
     if(!failedMoves.empty())
     {
-        emit moveFailed(failedMoves);
+        emit failed(failedMoves);
     }
     
     if(filesToMove.empty())
@@ -88,6 +88,6 @@ void MoveFileCommand::doMove(const QString& sourceFolder, const QString& destina
     }
     else
     {
-        emit moveSucceeded(filesToMove);
+        emit succeeded(filesToMove);
     }
 }

--- a/src/widgets/DocumentView.cpp
+++ b/src/widgets/DocumentView.cpp
@@ -21,6 +21,7 @@
 #include <QActionGroup>
 #include <QtConcurrent/QtConcurrent>
 #include <QColorDialog>
+#include <QMessageBox>
 
 #include <vector>
 #include <algorithm>
@@ -28,6 +29,7 @@
 #include "AfPointOverlay.hpp"
 #include "ExifOverlay.hpp"
 #include "SmartImageDecoder.hpp"
+#include "FileOperationConfigDialog.hpp"
 #include "ANPV.hpp"
 #include "Image.hpp"
 #include "DecoderFactory.hpp"
@@ -406,11 +408,22 @@ struct DocumentView::Impl
                 {
                     Entry_t nextImg = this->model->goTo(this->currentImageDecoder->image(), 1);
 
+                    ANPV::FileOperation op = FileOperationConfigDialog::operationFromAction(act);
                     QString targetDir = act->data().toString();
                     QFileInfo source = this->currentImageDecoder->image()->fileInfo();
-                    ANPV::globalInstance()->moveFiles({source.fileName()}, source.absoluteDir().absolutePath(), std::move(targetDir));
-
-                    p->loadImage(nextImg);
+                    switch(op)
+                    {
+                        case ANPV::FileOperation::Move:
+                            ANPV::globalInstance()->moveFiles({source.fileName()}, source.absoluteDir().absolutePath(), std::move(targetDir));
+                            p->loadImage(nextImg);
+                            break;
+                        case ANPV::FileOperation::HardLink:
+                            ANPV::globalInstance()->hardLinkFiles({source.fileName()}, source.absoluteDir().absolutePath(), std::move(targetDir));
+                            break;
+                        default:
+                            QMessageBox::information(p, "Not yet implemented", "not yet impl");
+                            break;
+                    }
                     break;
                 }
             }

--- a/src/widgets/FileOperationConfigDialog.cpp
+++ b/src/widgets/FileOperationConfigDialog.cpp
@@ -7,7 +7,7 @@
 #include <QDebug>
 #include <QActionGroup>
 #include <QDir>
-#include "ANPV.hpp"
+#include <QMetaEnum>
 
 FileOperationConfigDialog::FileOperationConfigDialog(QActionGroup* fileOperationActionGroup, QWidget *parent)
 : QDialog(parent),
@@ -32,42 +32,58 @@ FileOperationConfigDialog::~FileOperationConfigDialog()
     delete ui;
 }
 
+ANPV::FileOperation FileOperationConfigDialog::operationFromAction(QAction* a)
+{
+    QString text = a->text();
+    QStringList words = text.split(QStringLiteral(" "));
+    if(words.empty())
+    {
+        throw std::logic_error("This should never happen: words empty!");
+    }
+    QMetaEnum metaEnumOperation = QMetaEnum::fromType<ANPV::FileOperation>();
+    bool ok;
+    auto result = static_cast<ANPV::FileOperation>(metaEnumOperation.keyToValue(words[0].toLatin1().constData(), &ok));
+    if(!ok)
+    {
+        throw std::runtime_error("Unable to determine FileOperation type");
+    }
+    return result;
+}
+
 void FileOperationConfigDialog::fillDiag()
 {
+    QMetaEnum metaEnumOperation = QMetaEnum::fromType<ANPV::FileOperation>();
     QList<QAction*> actions = fileOperationActionGroup->actions();
     
-    auto uiBuilder = [&](QAction* action, QCheckBox* checkBox, QKeySequenceEdit* seqEdit, QLineEdit* lineEdit)
+    auto uiBuilder = [&](QAction* action, QComboBox* comboBox, QKeySequenceEdit* seqEdit, QLineEdit* lineEdit)
     {
-        lineEdit->setText(action->data().toString());
-        seqEdit->setKeySequence(action->shortcut());
-        checkBox->setCheckState(Qt::PartiallyChecked);
+        comboBox->addItem(metaEnumOperation.valueToKey(ANPV::FileOperation::Move));
+        comboBox->addItem(metaEnumOperation.valueToKey(ANPV::FileOperation::HardLink));
+        comboBox->addItem(metaEnumOperation.valueToKey(ANPV::FileOperation::Delete));
+        if(action != nullptr)
+        {
+            lineEdit->setText(action->data().toString());
+            seqEdit->setKeySequence(action->shortcut());
+            // the entries in the combo may not necessarily share the same index as the enum values
+            // hence use this complicated way of setting the right index
+            comboBox->setCurrentText(metaEnumOperation.valueToKey(this->operationFromAction(action)));
+        }
+        else
+        {
+            comboBox->setCurrentIndex(-1);
+        }
     };
-    
-    if(actions.size() < 1)
-        return;
-    
-    uiBuilder(actions[0], ui->checkBox, ui->keySequenceEdit, ui->lineEdit);
 
-    if(actions.size() < 2)
-        return;
-    
-    uiBuilder(actions[1], ui->checkBox_2, ui->keySequenceEdit_2, ui->lineEdit_2);
-
-    if(actions.size() < 3)
-        return;
-    
-    uiBuilder(actions[2], ui->checkBox_3, ui->keySequenceEdit_3, ui->lineEdit_3);
-
-    if(actions.size() < 4)
-        return;
-    
-    uiBuilder(actions[3], ui->checkBox_4, ui->keySequenceEdit_4, ui->lineEdit_4);
+    uiBuilder(actions.size() < 1 ? nullptr : actions[0], ui->comboBox, ui->keySequenceEdit, ui->lineEdit);
+    uiBuilder(actions.size() < 2 ? nullptr : actions[1], ui->comboBox_2, ui->keySequenceEdit_2, ui->lineEdit_2);
+    uiBuilder(actions.size() < 3 ? nullptr : actions[2], ui->comboBox_3, ui->keySequenceEdit_3, ui->lineEdit_3);
+    uiBuilder(actions.size() < 4 ? nullptr : actions[3], ui->comboBox_4, ui->keySequenceEdit_4, ui->lineEdit_4);
 
 }
 
 void FileOperationConfigDialog::accept()
 {
-    auto actionBuilder = [&](QCheckBox* checkBox, QKeySequenceEdit* seqEdit, QLineEdit* lineEdit)
+    auto actionBuilder = [&](QComboBox* comboBox, QKeySequenceEdit* seqEdit, QLineEdit* lineEdit)
     {
         QAction* action = nullptr;
         
@@ -76,10 +92,9 @@ void FileOperationConfigDialog::accept()
         if(targetDirInfo.isDir())
         {
             QKeySequence seq = seqEdit->keySequence();
-            bool isCopy = checkBox->checkState() == Qt::Checked;
             
-            QString title = isCopy ? "Copy " : "Move ";
-            title += "to ";
+            QString title = comboBox->currentText();
+            title += " to ";
             title += targetDir;
             action = new QAction(title, ANPV::globalInstance());
             action->setShortcut(seq);
@@ -100,19 +115,19 @@ void FileOperationConfigDialog::accept()
     }
     
     QAction* a;
-    a = actionBuilder(ui->checkBox, ui->keySequenceEdit, ui->lineEdit);
+    a = actionBuilder(ui->comboBox, ui->keySequenceEdit, ui->lineEdit);
     if(a)
         this->fileOperationActionGroup->addAction(a);
     
-    a = actionBuilder(ui->checkBox_2, ui->keySequenceEdit_2, ui->lineEdit_2);
+    a = actionBuilder(ui->comboBox_2, ui->keySequenceEdit_2, ui->lineEdit_2);
     if(a)
         this->fileOperationActionGroup->addAction(a);
     
-    a = actionBuilder(ui->checkBox_3, ui->keySequenceEdit_3, ui->lineEdit_3);
+    a = actionBuilder(ui->comboBox_3, ui->keySequenceEdit_3, ui->lineEdit_3);
     if(a)
         this->fileOperationActionGroup->addAction(a);
     
-    a = actionBuilder(ui->checkBox_4, ui->keySequenceEdit_4, ui->lineEdit_4);
+    a = actionBuilder(ui->comboBox_4, ui->keySequenceEdit_4, ui->lineEdit_4);
     if(a)
         this->fileOperationActionGroup->addAction(a);
     

--- a/src/widgets/FileOperationConfigDialog.hpp
+++ b/src/widgets/FileOperationConfigDialog.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QDialog>
+#include "ANPV.hpp"
 
 
 namespace Ui
@@ -10,6 +11,7 @@ namespace Ui
 
 class QActionGroup;
 class QLineEdit;
+class QAction;
 
 class FileOperationConfigDialog : public QDialog
 {
@@ -19,6 +21,7 @@ class FileOperationConfigDialog : public QDialog
     explicit FileOperationConfigDialog(QActionGroup* fileOperationActionGroup, QWidget *parent = nullptr);
     ~FileOperationConfigDialog() override;
 
+    static ANPV::FileOperation operationFromAction(QAction*);
     void accept() override;
     
 private:

--- a/src/widgets/FileOperationConfigDialog.ui
+++ b/src/widgets/FileOperationConfigDialog.ui
@@ -67,14 +67,7 @@
       </widget>
      </item>
      <item>
-      <widget class="QCheckBox" name="checkBox">
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Check the box to copy files, uncheck for moving files&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
+      <widget class="QComboBox" name="comboBox"/>
      </item>
      <item>
       <widget class="QLineEdit" name="lineEdit"/>
@@ -98,14 +91,7 @@
       </widget>
      </item>
      <item>
-      <widget class="QCheckBox" name="checkBox_2">
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Check the box to copy files, uncheck for moving files&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
+      <widget class="QComboBox" name="comboBox_2"/>
      </item>
      <item>
       <widget class="QLineEdit" name="lineEdit_2"/>
@@ -129,14 +115,7 @@
       </widget>
      </item>
      <item>
-      <widget class="QCheckBox" name="checkBox_3">
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Check the box to copy files, uncheck for moving files&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
+      <widget class="QComboBox" name="comboBox_3"/>
      </item>
      <item>
       <widget class="QLineEdit" name="lineEdit_3"/>
@@ -160,14 +139,7 @@
       </widget>
      </item>
      <item>
-      <widget class="QCheckBox" name="checkBox_4">
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Check the box to copy files, uncheck for moving files&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
+      <widget class="QComboBox" name="comboBox_4"/>
      </item>
      <item>
       <widget class="QLineEdit" name="lineEdit_4"/>

--- a/src/widgets/MainWindow.cpp
+++ b/src/widgets/MainWindow.cpp
@@ -237,8 +237,7 @@ struct MainWindow::Impl
             {
                 if((o == ui->thumbnailListView && ui->thumbnailListView->hasFocus()) || (o == ui->menuEdit && ui->menuEdit->hasFocus()))
                 {
-                    QString targetDir = act->data().toString();
-                    ui->thumbnailListView->moveSelectedFiles(std::move(targetDir));
+                    ui->thumbnailListView->fileOperationOnSelectedFiles(act);
                     break;
                 }
             }
@@ -255,7 +254,6 @@ struct MainWindow::Impl
             
             dia->open();
         });
-        this->refreshCopyMoveActions();
 
         connect(ui->actionAbout_ANPV, &QAction::triggered, ANPV::globalInstance(), &ANPV::about);
         connect(ui->actionAbout_Qt, &QAction::triggered, &QApplication::aboutQt);
@@ -309,6 +307,8 @@ struct MainWindow::Impl
         q->restoreGeometry(settings.value("geometry").toByteArray());
         q->restoreState(settings.value("windowState").toByteArray());
         settings.endGroup();
+        
+        this->refreshCopyMoveActions();
     }
     
     void onDirectoryTreeLoaded(const QString& s)

--- a/src/widgets/ThumbnailListView.cpp
+++ b/src/widgets/ThumbnailListView.cpp
@@ -97,6 +97,10 @@ struct ThumbnailListView::Impl
     
     void onCopyToClipboard(ANPV::FileOperation op)
     {
+        if (!(op == ANPV::FileOperation::Move || op == ANPV::FileOperation::Copy))
+        {
+            throw std::logic_error("Unsupported mode when copying to clipboard");
+        }
         QList<Entry_t> imgs = q->selectedImages();
         QList<QUrl> files;
         for(Entry_t& e : imgs)
@@ -208,9 +212,9 @@ ThumbnailListView::ThumbnailListView(QWidget *parent)
     d->actionMove->setShortcuts(QKeySequence::Cut);
     connect(d->actionMove, &QAction::triggered, this, [&](){ d->onCopyToClipboard(ANPV::FileOperation::Move); });
     
-    d->actionCopy = new QAction(QIcon::fromTheme("edit-copy"), "HardLink", this);
+    d->actionCopy = new QAction(QIcon::fromTheme("edit-copy"), "Copy", this);
     d->actionCopy->setShortcuts(QKeySequence::Copy);
-    connect(d->actionCopy, &QAction::triggered, this, [&](){ d->onCopyToClipboard(ANPV::FileOperation::HardLink); });
+    connect(d->actionCopy, &QAction::triggered, this, [&](){ d->onCopyToClipboard(ANPV::FileOperation::Copy); });
     
     d->actionDelete = new QAction(QIcon::fromTheme("edit-delete"), "Move To Trash", this);
     d->actionDelete->setShortcuts(QKeySequence::Delete);

--- a/src/widgets/ThumbnailListView.hpp
+++ b/src/widgets/ThumbnailListView.hpp
@@ -13,6 +13,7 @@
 class QAbstractItemModel;
 class QWheelEvent;
 class QWidget;
+class QAction;
 class SortedImageModel;
 class ThumbnailView;
 class Image;
@@ -27,7 +28,7 @@ public:
     ~ThumbnailListView() override;
     void setModel(QAbstractItemModel *model) override;
 
-    void moveSelectedFiles(QString&& destination);
+    void fileOperationOnSelectedFiles(QAction*);
     QList<Entry_t> selectedImages();
     QList<Entry_t> selectedImages(const QModelIndexList& selectedIdx);
         


### PR DESCRIPTION
Add hard linking support by using std::filesystem. Adjust the FileOperationConfigDialog to allow selecting the kind of operation.

Much of it is implemented with copy-paste and may become subject to future cleanups.