### PR TITLE
Do not allocate huge buffers for decoding small ROIs

### DIFF
--- a/src/decoders/SmartImageDecoder.cpp
+++ b/src/decoders/SmartImageDecoder.cpp
@@ -429,7 +429,7 @@ void SmartImageDecoder::convertColorSpace(QImage& image, bool silent)
             this->cancelCallback();
             if (!silent)
             {
-                this->updateDecodedRoiRect(QRect(0, y, width, linesToConvertNow));
+                this->updateDecodedRoiRect(QRect(image.offset() + QPoint(0, y), QSize(width, linesToConvertNow)));
             }
         }
     }

--- a/src/decoders/SmartImageDecoder.cpp
+++ b/src/decoders/SmartImageDecoder.cpp
@@ -498,7 +498,7 @@ QRect SmartImageDecoder::decodedRoiRect()
 
 void SmartImageDecoder::updateDecodedRoiRect(const QRect& r)
 {
-    d->decodedRoiRect = d->decodedRoiRect.united(r);
+    d->decodedRoiRect = d->decodedRoiRect.isValid() ? d->decodedRoiRect.united(r) : r;
     this->image()->updatePreviewImage(r);
 }
 

--- a/src/decoders/SmartImageDecoder.cpp
+++ b/src/decoders/SmartImageDecoder.cpp
@@ -537,6 +537,11 @@ void SmartImageDecoder::assertNotDecoding()
     }
 }
 
+QImage SmartImageDecoder::allocateImageBuffer(const QSize& s, QImage::Format format)
+{
+    return this->allocateImageBuffer(s.width(), s.height(), format);
+}
+
 QImage SmartImageDecoder::allocateImageBuffer(uint32_t width, uint32_t height, QImage::Format format)
 {
     switch(format)

--- a/src/decoders/SmartImageDecoder.hpp
+++ b/src/decoders/SmartImageDecoder.hpp
@@ -60,7 +60,8 @@ protected:
     QRect decodedRoiRect();
     void resetDecodedRoiRect();
     void updateDecodedRoiRect(const QRect& r);
-
+    
+    QImage allocateImageBuffer(const QSize& s, QImage::Format format);
     QImage allocateImageBuffer(uint32_t width, uint32_t height, QImage::Format format);
     void convertColorSpace(QImage& image, bool silent = false);
 

--- a/src/decoders/SmartImageDecoder.hpp
+++ b/src/decoders/SmartImageDecoder.hpp
@@ -65,6 +65,9 @@ protected:
     QImage allocateImageBuffer(uint32_t width, uint32_t height, QImage::Format format);
     void convertColorSpace(QImage& image, bool silent = false);
 
+    QTransform fullResToPageTransform(const QSize& desiredResolution);
+    QTransform fullResToPageTransform(unsigned w, unsigned h);
+
     void setDecodingState(DecodingState state);
     void setDecodingMessage(QString&& msg);
     void setDecodingProgress(int prog);

--- a/src/decoders/SmartImageDecoder.hpp
+++ b/src/decoders/SmartImageDecoder.hpp
@@ -63,7 +63,7 @@ protected:
     
     QImage allocateImageBuffer(const QSize& s, QImage::Format format);
     QImage allocateImageBuffer(uint32_t width, uint32_t height, QImage::Format format);
-    void convertColorSpace(QImage& image, bool silent = false);
+    void convertColorSpace(QImage& image, bool silent = false, QTransform = QTransform());
 
     QTransform fullResToPageTransform(const QSize& desiredResolution);
     QTransform fullResToPageTransform(unsigned w, unsigned h);

--- a/src/decoders/SmartImageDecoder.hpp
+++ b/src/decoders/SmartImageDecoder.hpp
@@ -49,6 +49,7 @@ public:
     void run() override;
     void cancelOrTake(QFuture<DecodingState> taskFuture);
     void releaseFullImage();
+    QRect decodedRoiRect();
 
 protected:
     virtual void decodeHeader(const unsigned char* buffer, qint64 nbytes) = 0;
@@ -57,7 +58,6 @@ protected:
     void cancelCallback();
     void assertNotDecoding();
 
-    QRect decodedRoiRect();
     void resetDecodedRoiRect();
     void updateDecodedRoiRect(const QRect& r);
     

--- a/src/decoders/SmartJpegDecoder.cpp
+++ b/src/decoders/SmartJpegDecoder.cpp
@@ -253,7 +253,7 @@ QImage SmartJpegDecoder::decodingLoop(QSize desiredResolution, QRect roiRect)
             auto linesRead = jpeg_read_scanlines(&cinfo, &bufferSetup[cinfo.output_scanline - skippedScanlinesTop], cinfo.rec_outbuf_height);
             this->cancelCallback();
 
-            this->updateDecodedRoiRect(currentResToFullResTrafo.mapRect(QRect(xoffset, cinfo.output_scanline, croppedWidth, linesRead)));
+            this->updateDecodedRoiRect(currentResToFullResTrafo.mapRect(QRect(xoffset, cinfo.output_scanline - linesRead, croppedWidth, linesRead)));
         }
         
         /* terminate output pass */
@@ -268,7 +268,7 @@ QImage SmartJpegDecoder::decodingLoop(QSize desiredResolution, QRect roiRect)
 // //     this->setDecodingMessage("Applying final smooth rescaling...");
 // //     image = image.scaled(desiredResolution, Qt::KeepAspectRatio, Qt::SmoothTransformation);
 
-    this->convertColorSpace(image);
+    this->convertColorSpace(image, false, currentResToFullResTrafo);
 
     if (progressiveGuard >= 1000)
     {

--- a/src/decoders/SmartJpegDecoder.cpp
+++ b/src/decoders/SmartJpegDecoder.cpp
@@ -144,7 +144,7 @@ QImage SmartJpegDecoder::decodingLoop(QSize desiredResolution, QRect roiRect)
     std::vector<JSAMPLE*> bufferSetup;
     QImage image;
     QRect scaledRoi;
-    QTransform currentResToFullResTrafo;
+    QTransform currentResToFullResTrafo, fullResToCurrentRes;
     
     if (setjmp(d->jerr.setjmp_buffer))
     {
@@ -175,9 +175,9 @@ QImage SmartJpegDecoder::decodingLoop(QSize desiredResolution, QRect roiRect)
     jpeg_calc_output_dimensions(&cinfo);
 
     // update the scale because output dimensions might be a bit different to what we requested
-    scale = std::min(cinfo.output_width * 1.0 / cinfo.image_width, cinfo.output_height * 1.0 / cinfo.image_height);
+    fullResToCurrentRes = this->fullResToPageTransform(cinfo.output_width, cinfo.output_height);
 
-    scaledRoi = QRect(std::floor(roiRect.x() * scale), std::floor(roiRect.y() * scale), std::floor(roiRect.width() * scale), std::floor(roiRect.height() * scale));
+    scaledRoi = fullResToCurrentRes.mapRect(roiRect);
     Q_ASSERT(scaledRoi.isValid());
     Q_ASSERT(scaledRoi.width() <= cinfo.output_width);
     Q_ASSERT(scaledRoi.height() <= cinfo.output_height);
@@ -190,31 +190,27 @@ QImage SmartJpegDecoder::decodingLoop(QSize desiredResolution, QRect roiRect)
         qWarning() << "I/O suspension after jpeg_start_decompress()";
     }
 
-    // TODO: The buffer allocation should be done after cropping the scanline
-    image = this->allocateImageBuffer(cinfo.output_width, cinfo.output_height, QImage::Format_ARGB32);
-    auto* dataPtrBackup = image.constBits();
-    currentResToFullResTrafo = this->fullResToPageTransform(cinfo.output_width, cinfo.output_height).inverted();
-    this->image()->setDecodedImage(image, currentResToFullResTrafo);
-    this->resetDecodedRoiRect();
-
     JDIMENSION xoffset = scaledRoi.x();
     JDIMENSION croppedWidth = scaledRoi.width();
-    if (xoffset > 0 && croppedWidth > 0)
-    {
-        cinfo.global_state = 205;
-        jpeg_crop_scanline(&cinfo, &xoffset, &croppedWidth);
-        cinfo.global_state = 207;
-    }
+    jpeg_crop_scanline(&cinfo, &xoffset, &croppedWidth);
+    scaledRoi.setX(xoffset);
+    scaledRoi.setWidth(croppedWidth);
+
     const JDIMENSION skippedScanlinesTop = scaledRoi.y();
     const JDIMENSION lastScanlineToDecode = skippedScanlinesTop + scaledRoi.height();
 
-    // TODO: buffer allocation should be done here
+    image = this->allocateImageBuffer(scaledRoi.width(), scaledRoi.height(), QImage::Format_ARGB32);
+    auto* dataPtrBackup = image.constBits();
+    currentResToFullResTrafo = fullResToCurrentRes.inverted();
+    image.setOffset(currentResToFullResTrafo.mapRect(scaledRoi).topLeft());
 
-    bufferSetup.resize(cinfo.output_height / cinfo.rec_outbuf_height);
+    this->image()->setDecodedImage(image, currentResToFullResTrafo);
+    this->resetDecodedRoiRect();
+
+    bufferSetup.resize(image.height() / cinfo.rec_outbuf_height);
     for (JDIMENSION i = 0; i < bufferSetup.size(); i++)
     {
         bufferSetup[i] = const_cast<JSAMPLE*>(image.constScanLine(i * cinfo.rec_outbuf_height));
-        bufferSetup[i] += xoffset * sizeof(uint32_t);
     }
     
     this->cancelCallback();
@@ -252,14 +248,12 @@ QImage SmartJpegDecoder::decodingLoop(QSize desiredResolution, QRect roiRect)
         /* start a new output pass */
         jpeg_start_output(&cinfo, cinfo.input_scan_number);
         auto acuallySkipped = jpeg_skip_scanlines(&cinfo, skippedScanlinesTop);
-        auto totalLinesRead = cinfo.output_scanline;
         while (cinfo.output_scanline < lastScanlineToDecode)
         {
-            auto linesRead = jpeg_read_scanlines(&cinfo, bufferSetup.data()+cinfo.output_scanline, cinfo.rec_outbuf_height);
+            auto linesRead = jpeg_read_scanlines(&cinfo, &bufferSetup[cinfo.output_scanline - skippedScanlinesTop], cinfo.rec_outbuf_height);
             this->cancelCallback();
 
-            this->updateDecodedRoiRect(currentResToFullResTrafo.mapRect(QRect(xoffset, totalLinesRead, croppedWidth, linesRead)));
-            totalLinesRead += linesRead;
+            this->updateDecodedRoiRect(currentResToFullResTrafo.mapRect(QRect(xoffset, cinfo.output_scanline, croppedWidth, linesRead)));
         }
         
         /* terminate output pass */

--- a/src/decoders/SmartJpegDecoder.cpp
+++ b/src/decoders/SmartJpegDecoder.cpp
@@ -192,7 +192,7 @@ QImage SmartJpegDecoder::decodingLoop(QSize desiredResolution, QRect roiRect)
     // TODO: The buffer allocation should be done after cropping the scanline
     image = this->allocateImageBuffer(cinfo.output_width, cinfo.output_height, QImage::Format_ARGB32);
     auto* dataPtrBackup = image.constBits();
-    this->image()->setDecodedImage(image);
+    this->image()->setDecodedImage(image, this->fullResToPageTransform(cinfo.output_width, cinfo.output_height).inverted());
     this->resetDecodedRoiRect();
 
     JDIMENSION xoffset = scaledRoi.x();

--- a/src/decoders/SmartTiffDecoder.cpp
+++ b/src/decoders/SmartTiffDecoder.cpp
@@ -642,7 +642,7 @@ gehtnich:
                     const unsigned linesToSkipFromTop = y < areaToCopy.y() ? areaToCopy.y() - y : 0;
                     for(unsigned i=0; i < (unsigned)areaToCopy.height(); i++)
                     {
-                        ::memcpy(&buf[destRow++*image.width()+0], &stripBufUncrustified.data()[(i+linesToSkipFromTop) * width + areaToCopy.x()], areaToCopy.width() * sizeof(uint32_t));
+                        ::memcpy(&buf[size_t(destRow++)*image.width()+0], &stripBufUncrustified.data()[(i+linesToSkipFromTop) * width + areaToCopy.x()], areaToCopy.width() * sizeof(uint32_t));
                     }
                     
                     QRect mappedArea = currentPageToFullResTransform.mapRect(areaToCopy);

--- a/src/decoders/SmartTiffDecoder.cpp
+++ b/src/decoders/SmartTiffDecoder.cpp
@@ -447,7 +447,7 @@ QImage SmartTiffDecoder::decodingLoop(QSize desiredResolution, QRect roiRect)
         }
     }
     
-    image.setOffset(mappedRoi.topLeft());
+    image.setOffset(roiRect.topLeft());
 
     this->image()->setDecodedImage(image);
     this->resetDecodedRoiRect();

--- a/src/decoders/SmartTiffDecoder.cpp
+++ b/src/decoders/SmartTiffDecoder.cpp
@@ -475,8 +475,6 @@ void SmartTiffDecoder::decodeInternal(int imagePageToDecode, QImage& image, QRec
     const auto& width = d->pageInfos[imagePageToDecode].width;
     const auto& height = d->pageInfos[imagePageToDecode].height;
     
-    bool skipColorTransform = false;
-    
     if(!roi.isValid())
     {
         // roi's coordinates are native to imagePageToDecode
@@ -521,7 +519,6 @@ void SmartTiffDecoder::decodeInternal(int imagePageToDecode, QImage& image, QRec
                 QRect areaToCopy = tileRect.intersected(roi);
                 if(areaToCopy.isEmpty())
                 {
-                    skipColorTransform = true;
                     continue;
                 }
             
@@ -656,16 +653,7 @@ gehtnich:
         }
     }
 
-    if(skipColorTransform)
-    {
-        this->setDecodingMessage("Partial decoding finished, but color transforming is not yet supported for partial decoded images.");
-        // it would also transform the non-decoded surrounding void, which is very memory expensive...
-    }
-    else
-    {
-        this->convertColorSpace(image);
-        this->setDecodingMessage("TIFF decoding completed successfully.");
-    }
-
+    this->convertColorSpace(image);
+    this->setDecodingMessage("TIFF decoding completed successfully.");
     this->setDecodingProgress(100);
 }

--- a/src/decoders/SmartTiffDecoder.cpp
+++ b/src/decoders/SmartTiffDecoder.cpp
@@ -418,6 +418,7 @@ QImage SmartTiffDecoder::decodingLoop(QSize desiredResolution, QRect roiRect)
     QTransform scaleTrafo = QTransform::fromScale(actualPageScaleXInverted, actualPageScaleYInverted);
     QRect mappedRoi = scaleTrafo.mapRect(targetImageRect);
 
+    qDebug() << "actualPageScaleXInverted: " << actualPageScaleXInverted<< "   |   actualPageScaleYInverted: " <<actualPageScaleYInverted ;
     QImage image = this->allocateImageBuffer(mappedRoi.size(), d->format(imagePageToDecode));
 
     // RESOLUTIONUNIT must be read and set now (and not in decodeInternal), because QImage::setDotsPerMeterXY() calls detach() and therefore copies the entire image!!!
@@ -449,7 +450,7 @@ QImage SmartTiffDecoder::decodingLoop(QSize desiredResolution, QRect roiRect)
     
     image.setOffset(roiRect.topLeft());
 
-    this->image()->setDecodedImage(image);
+    this->image()->setDecodedImage(image, QTransform::fromScale(1/actualPageScaleXInverted, 1/actualPageScaleYInverted));
     this->resetDecodedRoiRect();
     this->decodeInternal(imagePageToDecode, image, mappedRoi, desiredScaleX, desiredResolution);
 

--- a/src/decoders/SmartTiffDecoder.cpp
+++ b/src/decoders/SmartTiffDecoder.cpp
@@ -537,7 +537,13 @@ void SmartTiffDecoder::decodeInternal(int imagePageToDecode, QImage& image, QRec
                     for (unsigned i = linesToSkip; i < (unsigned)areaToCopy.height(); i++)
                     {
                         // brainfuck ahead...
-                        d->convert32BitOrder(&buf[size_t(y+i - roi.y())*image.width() + destCol], &tileBuf[(tl-i-1)*tw + (x<areaToCopy.x() ? widthToSkip : 0)], 1, areaToCopy.width());
+                        // determine the destinationRow to write to, make it size_t to avoid 32bit overflow for panorama images
+                        size_t destRow = y+i - roi.y();
+                        // the source row to read from, we need to start from the bottom (i.e. last pixel row of the tile), -1 because tl is a size but we need an index
+                        unsigned srcRow = tl-i-1;
+                        // the source column to read from, if a tile intersects to the left of areaToCopy, we need to skip widthToSkip pixels, if a tile intersects at the right, we start with with the first pixel
+                        unsigned srcCol = x<areaToCopy.x() ? widthToSkip : 0;
+                        d->convert32BitOrder(&buf[destRow*image.width() + destCol], &tileBuf[srcRow*tw + srcCol], 1, areaToCopy.width());
                     }
                     destCol += areaToCopy.width();
                     

--- a/src/decoders/SmartTiffDecoder.cpp
+++ b/src/decoders/SmartTiffDecoder.cpp
@@ -450,6 +450,7 @@ QImage SmartTiffDecoder::decodingLoop(QSize desiredResolution, QRect roiRect)
     this->image()->setDecodedImage(image, toFullScaleTransform);
     this->resetDecodedRoiRect();
     this->decodeInternal(imagePageToDecode, image, mappedRoi, toFullScaleTransform, desiredResolution);
+    this->convertColorSpace(image, false, toFullScaleTransform);
 
     bool fullImageDecoded = (imagePageToDecode == d->findHighestResolution(d->pageInfos)); // We have decoded the highest resolution available
     fullImageDecoded &= ((unsigned)image.width() >= d->pageInfos[imagePageToDecode].width && (unsigned)image.height() >= d->pageInfos[imagePageToDecode].height); // we have not used the fast decoding hack
@@ -655,7 +656,6 @@ gehtnich:
         }
     }
 
-    this->convertColorSpace(image);
     this->setDecodingMessage("TIFF decoding completed successfully.");
     this->setDecodingProgress(100);
 }

--- a/src/decoders/SmartTiffDecoder.cpp
+++ b/src/decoders/SmartTiffDecoder.cpp
@@ -537,7 +537,7 @@ void SmartTiffDecoder::decodeInternal(int imagePageToDecode, QImage& image, QRec
                     for (unsigned i = linesToSkip; i < (unsigned)areaToCopy.height(); i++)
                     {
                         // brainfuck ahead...
-                        d->convert32BitOrder(&buf[size_t(y+i - roi.y())*image.width() + destCol], &tileBuf[(tl-i-1)*tw + widthToSkip], 1, areaToCopy.width());
+                        d->convert32BitOrder(&buf[size_t(y+i - roi.y())*image.width() + destCol], &tileBuf[(tl-i-1)*tw + (x<areaToCopy.x() ? widthToSkip : 0)], 1, areaToCopy.width());
                     }
                     destCol += areaToCopy.width();
                     

--- a/src/decoders/SmartTiffDecoder.cpp
+++ b/src/decoders/SmartTiffDecoder.cpp
@@ -651,7 +651,7 @@ gehtnich:
         }
     }
 
-    this->convertColorSpace(image, true);
+    this->convertColorSpace(image);
     this->setDecodingMessage("TIFF decoding completed successfully.");
     this->setDecodingProgress(100);
 }

--- a/src/decoders/SmartTiffDecoder.hpp
+++ b/src/decoders/SmartTiffDecoder.hpp
@@ -27,5 +27,5 @@ protected:
 private:
     struct Impl;
     std::unique_ptr<Impl> d;
-    void decodeInternal(int imagePageToDecode, QImage& image, QRect roi, double desiredDecodeScale, QSize desiredResolution);
+    void decodeInternal(int imagePageToDecode, QImage& image, QRect roi, QTransform, QSize desiredResolution);
 };

--- a/src/logic/Image.cpp
+++ b/src/logic/Image.cpp
@@ -98,6 +98,7 @@ Image::Image(const QFileInfo& url) : d(std::make_unique<Impl>(url))
         {
             std::unique_lock<std::recursive_mutex> lck(d->m);
             QRect updateRect = d->cachedUpdateRect;
+            Q_ASSERT(updateRect.isValid());
             d->cachedUpdateRect = QRect();
             lck.unlock();
             emit this->previewImageUpdated(this, updateRect);
@@ -481,6 +482,7 @@ void Image::updatePreviewImage(const QRect& r)
     QRect updateRect = d->cachedUpdateRect;
     updateRect = updateRect.isValid() ? updateRect.united(r) : r;
     d->cachedUpdateRect = updateRect;
+    Q_ASSERT(updateRect.isValid());
     lck.unlock();
 
     QMetaObject::invokeMethod(this, [&]()

--- a/src/logic/Image.cpp
+++ b/src/logic/Image.cpp
@@ -479,7 +479,7 @@ void Image::updatePreviewImage(const QRect& r)
 {
     std::unique_lock<std::recursive_mutex> lck(d->m);
     QRect updateRect = d->cachedUpdateRect;
-    updateRect = updateRect.united(r);
+    updateRect = updateRect.isValid() ? updateRect.united(r) : r;
     d->cachedUpdateRect = updateRect;
     lck.unlock();
 

--- a/src/logic/Image.cpp
+++ b/src/logic/Image.cpp
@@ -98,7 +98,10 @@ Image::Image(const QFileInfo& url) : d(std::make_unique<Impl>(url))
         {
             std::unique_lock<std::recursive_mutex> lck(d->m);
             QRect updateRect = d->cachedUpdateRect;
-            Q_ASSERT(updateRect.isValid());
+            if (!updateRect.isValid())
+            {
+                return;
+            }
             d->cachedUpdateRect = QRect();
             lck.unlock();
             emit this->previewImageUpdated(this, updateRect);

--- a/src/logic/Image.cpp
+++ b/src/logic/Image.cpp
@@ -466,13 +466,13 @@ QImage Image::decodedImage()
     return d->decodedImage;
 }
 
-void Image::setDecodedImage(QImage img)
+void Image::setDecodedImage(QImage img, QTransform scale)
 {
     std::unique_lock<std::recursive_mutex> lck(d->m);
     // skip comparison with current image, can be slow
     d->decodedImage = img;
     lck.unlock();
-    emit this->decodedImageChanged(this, d->decodedImage);
+    emit this->decodedImageChanged(this, d->decodedImage, scale);
 }
 
 void Image::updatePreviewImage(const QRect& r)
@@ -512,7 +512,7 @@ void Image::connectNotify(const QMetaMethod& signal)
         QImage img = this->decodedImage();
         if(!img.isNull())
         {
-            emit this->decodedImageChanged(this, img);
+            emit this->decodedImageChanged(this, img, QTransform());
         }
     }
     else if (signal.name() == QStringLiteral("checkStateChanged"))

--- a/src/logic/Image.hpp
+++ b/src/logic/Image.hpp
@@ -11,6 +11,7 @@
 #include <QString>
 #include <QFileInfo>
 #include <QFuture>
+#include <QTransform>
 #include <functional>
 #include <memory>
 #include <stdexcept>
@@ -86,7 +87,7 @@ public slots:
 signals:
     void decodingStateChanged(Image* self, quint32 newState, quint32 oldState);
     void thumbnailChanged(Image* self, QImage);
-    void decodedImageChanged(Image* self, QImage img);
+    void decodedImageChanged(Image* self, QImage img, QTransform sc);
     void previewImageUpdated(Image* self, QRect r);
     void checkStateChanged(Image* self, int newState, int oldState);
 
@@ -100,7 +101,7 @@ protected:
     void setColorSpace(QColorSpace);
     
     void setDecodingState(DecodingState state);
-    void setDecodedImage(QImage);
+    void setDecodedImage(QImage, QTransform s=QTransform());
     void setErrorMessage(const QString&);
     
     void updatePreviewImage(const QRect& r);

--- a/src/widgets/DocumentView.cpp
+++ b/src/widgets/DocumentView.cpp
@@ -109,6 +109,8 @@ struct DocumentView::Impl
         thumbnailPreviewOverlay->setPixmap(QPixmap());
         thumbnailPreviewOverlay->hide();
         
+        debugOverlay1->hide();
+        
         afPointOverlay->hide();
         
         messageWidget->hide();

--- a/src/widgets/DocumentView.cpp
+++ b/src/widgets/DocumentView.cpp
@@ -748,6 +748,7 @@ void DocumentView::onPreviewImageUpdated(Image* img, QRect r)
         // ignore events from a previous decoder that might still be running in the background
         return;
     }
+    qDebug() << "onPreviewImageUpdated: " << r;
     d->currentPixmapOverlay->update(r);
 }
 

--- a/src/widgets/DocumentView.cpp
+++ b/src/widgets/DocumentView.cpp
@@ -173,7 +173,7 @@ struct DocumentView::Impl
     void createSmoothPixmap()
     {
         xThreadGuard g(q);
-        if (currentDocumentPixmap.isNull())
+//         if (currentDocumentPixmap.isNull())
         {
             return;
         }
@@ -556,7 +556,6 @@ DocumentView::DocumentView(QWidget *parent)
     
     d->smoothPixmapOverlay = new QGraphicsPixmapItem;
     d->smoothPixmapOverlay->setZValue(-8);
-    d->currentPixmapOverlay->setTransformationMode(Qt::SmoothTransformation);
     d->scene->addItem(d->smoothPixmapOverlay);
     
     d->afPointOverlay = new AfPointOverlay;
@@ -746,10 +745,13 @@ void DocumentView::onImageRefinement(Image* img, QImage image)
 
     d->currentDocumentPixmap = QPixmap::fromImage(image, Qt::NoFormatConversion);
     d->currentPixmapOverlay->setPixmap(d->currentDocumentPixmap);
+    d->currentPixmapOverlay->setOffset(d->currentPixmapOverlay->mapFromScene(image.offset()));
 
     QSize fullImageSize = img->size();
-    auto newScale = (fullImageSize.width() * 1.0 / d->currentDocumentPixmap.width());
-    d->currentPixmapOverlay->setScale(newScale);
+    auto newScaleX = (fullImageSize.width() * 1.0 / (d->currentPixmapOverlay->boundingRect().width() + d->currentPixmapOverlay->offset().x()));
+    auto newScaleY = (fullImageSize.height() * 1.0 / (d->currentPixmapOverlay->boundingRect().height() + d->currentPixmapOverlay->offset().y()));
+    qDebug() << "scaleX: " << newScaleX << "   |   scaleY: " << newScaleY << "   |    offset: " << image.offset();
+    d->currentPixmapOverlay->setScale(newScaleY);
     d->currentPixmapOverlay->show();
 
     d->scene->invalidate();

--- a/src/widgets/DocumentView.cpp
+++ b/src/widgets/DocumentView.cpp
@@ -735,7 +735,7 @@ void DocumentView::onPreviewImageUpdated(Image* img, QRect r)
     d->currentPixmapOverlay->update(r);
 }
 
-void DocumentView::onImageRefinement(Image* img, QImage image)
+void DocumentView::onImageRefinement(Image* img, QImage image, QTransform scale)
 {
     if(img != this->d->currentImageDecoder->image().data())
     {
@@ -745,13 +745,13 @@ void DocumentView::onImageRefinement(Image* img, QImage image)
 
     d->currentDocumentPixmap = QPixmap::fromImage(image, Qt::NoFormatConversion);
     d->currentPixmapOverlay->setPixmap(d->currentDocumentPixmap);
+    d->currentPixmapOverlay->setTransform(scale, false);
     d->currentPixmapOverlay->setOffset(d->currentPixmapOverlay->mapFromScene(image.offset()));
-
+/*
     QSize fullImageSize = img->size();
     auto newScaleX = (fullImageSize.width() * 1.0 / (d->currentPixmapOverlay->boundingRect().width() + d->currentPixmapOverlay->offset().x()));
     auto newScaleY = (fullImageSize.height() * 1.0 / (d->currentPixmapOverlay->boundingRect().height() + d->currentPixmapOverlay->offset().y()));
-    qDebug() << "scaleX: " << newScaleX << "   |   scaleY: " << newScaleY << "   |    offset: " << image.offset();
-    d->currentPixmapOverlay->setScale(newScaleY);
+    qDebug() << "scaleX: " << newScaleX << "   |   scaleY: " << newScaleY << "   |    offset: " << image.offset();*/
     d->currentPixmapOverlay->show();
 
     d->scene->invalidate();
@@ -778,7 +778,7 @@ void DocumentView::onDecodingStateChanged(Image* img, quint32 newState, quint32 
     }
     case DecodingState::FullImage:
     {
-        this->onImageRefinement(dec->image().data(), dec->image()->decodedImage());
+        this->onImageRefinement(dec->image().data(), dec->image()->decodedImage(), QTransform());
 
         d->thumbnailPreviewOverlay->hide();
         break;

--- a/src/widgets/DocumentView.hpp
+++ b/src/widgets/DocumentView.hpp
@@ -7,6 +7,7 @@
 #include <QImage>
 #include <QString>
 #include <QFileInfo>
+#include <QTransform>
 
 class ANPV;
 class Image;
@@ -39,7 +40,7 @@ public slots:
     void zoomIn();
     void zoomOut();
     void onPreviewImageUpdated(Image* img, QRect r);
-    void onImageRefinement(Image* self, QImage img);
+    void onImageRefinement(Image* self, QImage img, QTransform);
     void onDecodingStateChanged(Image* self, quint32 newState, quint32 oldState);
     void onCheckStateChanged(Image* img, int state, int old);
 


### PR DESCRIPTION
Allocate only as much memory as really needed. This also fixes color transformation for tiled TIFFs. For the moment, smooth pixmap scaling has been disabled (should be done by the decoder anyway, rather than UI thread).

Resolves #33