### PR TITLE
Fix images appearing in wrong order

### DIFF
--- a/src/models/ImageSectionDataContainer.cpp
+++ b/src/models/ImageSectionDataContainer.cpp
@@ -383,7 +383,12 @@ int ImageSectionDataContainer::getLinearIndexOfItem(const AbstractListItem* item
 void ImageSectionDataContainer::clear()
 {
     std::unique_lock<std::recursive_mutex> l(d->m);
+    
     auto rowCount = this->size();
+    if (rowCount == 0)
+    {
+        return;
+    }
 
     QMetaObject::invokeMethod(d->model, [rowCount, this]()
         {
@@ -422,8 +427,11 @@ int ImageSectionDataContainer::size() const
 void ImageSectionDataContainer::sortImageItems(SortField imageSortField, Qt::SortOrder order)
 {
     std::lock_guard<std::recursive_mutex> l(d->m);
-    auto rowCount = this->size();
     
+    d->imageSortField = imageSortField;
+    d->imageSortOrder = order;
+    
+    auto rowCount = this->size();
     if(rowCount == 0)
     {
         return;
@@ -438,9 +446,7 @@ void ImageSectionDataContainer::sortImageItems(SortField imageSortField, Qt::Sor
     {
         (*it)->sortItems(imageSortField, order);
     }
-    d->imageSortField = imageSortField;
-    d->imageSortOrder = order;
-
+    
     auto itemsForUIModel = d->flatListForUI();
     QMetaObject::invokeMethod(d->model, [itemsForUIModel, this]()
         {
@@ -454,8 +460,11 @@ void ImageSectionDataContainer::sortImageItems(SortField imageSortField, Qt::Sor
 void ImageSectionDataContainer::sortSections(SortField sectionSortField, Qt::SortOrder order)
 {
     std::lock_guard<std::recursive_mutex> l(d->m);
+
+    d->sectionSortOrder = order;
+    d->sectionSortField = sectionSortField;
+
     auto rowCount = this->size();
-    
     if(rowCount == 0)
     {
         return;
@@ -467,8 +476,6 @@ void ImageSectionDataContainer::sortSections(SortField sectionSortField, Qt::Sor
         }, Qt::AutoConnection);
 
     std::sort(this->d->data.begin(), this->d->data.end(), d->getSortFunction(order));
-    d->sectionSortOrder = order;
-    d->sectionSortField = sectionSortField;
 
     auto itemsForUIModel = d->flatListForUI();
     QMetaObject::invokeMethod(d->model, [itemsForUIModel, this]()

--- a/src/models/SortedImageModel.cpp
+++ b/src/models/SortedImageModel.cpp
@@ -124,7 +124,7 @@ struct SortedImageModel::Impl
 
         cancelAllBackgroundTasks();
         this->checkedImages.clear();
-        this->visibleItemList.clear();
+        // this->visibleItemList.clear(); Will be cleared via a delayed event by ImageSectionDataContainer::clear()
         this->layoutChangedTimer->setInterval(500);
         
         q->endResetModel();

--- a/src/models/SortedImageModel.hpp
+++ b/src/models/SortedImageModel.hpp
@@ -20,7 +20,6 @@ class AbstractListItem;
 class SortedImageModel : public QAbstractTableModel
 {
     Q_OBJECT
-    friend class ImageSectionDataContainer;
     
 public:
 


### PR DESCRIPTION
When quickly refreshing the ThumbnailView by pressing F5, items may appear in the wrong order. That was due to a race between `SortedImageModel::Impl::clear()` and events emitted by `ImageSectionDataContainer::addImageItem()`.