### PR TITLE
Support image browsing when opening distinct images

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -103,7 +103,6 @@ int main(int argc, char *argv[])
             for (int i = 1; i < argc; i++)
             {
                 QFileInfo fileInfo(QString::fromLocal8Bit(argv[i]));
-                auto emplacedImage = DecoderFactory::globalInstance()->makeImage(fileInfo);
 
                 if (currentDirModel == nullptr || fileInfo.canonicalPath() != prevFileInfo.canonicalPath())
                 {
@@ -118,6 +117,7 @@ int main(int argc, char *argv[])
                     task.waitForFinished();
                 }
 
+                auto emplacedImage = AbstractListItem::imageCast(currentDirModel->getItemByLinearIndex(currentDirModel->getLinearIndexOfItem(fileInfo)));
                 imagesWithFileModel.push_back({ emplacedImage, currentDirModel });
                 prevFileInfo = fileInfo;
             }

--- a/main.cpp
+++ b/main.cpp
@@ -109,6 +109,7 @@ int main(int argc, char *argv[])
                     splash.showMessage(QString("Discover directory contents %1").arg(fileInfo.canonicalPath()));
 
                     currentDirModel.reset(new ImageSectionDataContainer(nullptr));
+                    currentDirModel->setDecodingState(DecodingState::Ready);
                     currentDirModel->sortSections(SortField::None, Qt::AscendingOrder);
                     currentDirModel->sortImageItems(SortField::FileName, Qt::AscendingOrder);
                     DirectoryWorker w(currentDirModel.data());

--- a/src/logic/ANPV.cpp
+++ b/src/logic/ANPV.cpp
@@ -207,11 +207,11 @@ struct ANPV::Impl
                 {
                     QList<QString> files = q->getExistingFile(QApplication::focusWidget(), lastOpenImageDir);
                     
-                    QList<QSharedPointer<Image>> images;
+                    QList<std::pair<QSharedPointer<Image>, QSharedPointer<ImageSectionDataContainer>>> images;
                     images.reserve(files.size());
                     for(auto& f : files)
                     {
-                        images.emplace_back(DecoderFactory::globalInstance()->makeImage(QFileInfo(f)));
+                        images.emplace_back(DecoderFactory::globalInstance()->makeImage(QFileInfo(f)), this->fileModel->dataContainer());
                     }
                     q->openImages(images);
                 });
@@ -775,7 +775,7 @@ void ANPV::showThumbnailView(QSplashScreen* splash)
     splash->finish(d->mainWindow.get());
 }
 
-void ANPV::openImages(const QList<QSharedPointer<Image>>& image)
+void ANPV::openImages(const QList<std::pair<QSharedPointer<Image>, QSharedPointer<ImageSectionDataContainer>>>& image)
 {
     xThreadGuard g(this);
     if(image.isEmpty())
@@ -785,7 +785,7 @@ void ANPV::openImages(const QList<QSharedPointer<Image>>& image)
     }
     WaitCursor w;
     MultiDocumentView* mdv = new MultiDocumentView(d->mainWindow.get());
-    mdv->addImages(image, d->fileModel);
+    mdv->addImages(image);
     mdv->show();
 }
 

--- a/src/logic/ANPV.hpp
+++ b/src/logic/ANPV.hpp
@@ -49,7 +49,7 @@ public:
     QThread* backgroundThread();
     QSettings& settings();
 
-    void openImages(const QList<QSharedPointer<Image>>&);
+    void openImages(const QList<std::pair<QSharedPointer<Image>, QSharedPointer<ImageSectionDataContainer>>>&);
     void showThumbnailView();
     void showThumbnailView(QSplashScreen*);
     

--- a/src/models/AbstractListItem.cpp
+++ b/src/models/AbstractListItem.cpp
@@ -54,3 +54,13 @@ ListItemType AbstractListItem::getType() const
 {
     return d->type;
 }
+
+QSharedPointer<Image> AbstractListItem::imageCast(const QSharedPointer<AbstractListItem>& item)
+{
+    if (item != nullptr && item->getType() == ListItemType::Image)
+    {
+        return qSharedPointerDynamicCast<Image>(item);
+    }
+
+    return nullptr;
+}

--- a/src/models/AbstractListItem.hpp
+++ b/src/models/AbstractListItem.hpp
@@ -10,6 +10,8 @@ class AbstractListItem
 public:
     AbstractListItem(ListItemType type);
     virtual ~AbstractListItem();
+
+    static QSharedPointer<Image> imageCast(const QSharedPointer<AbstractListItem>& item);
     
     virtual QString getName() const = 0;
     ListItemType getType() const;

--- a/src/models/ImageSectionDataContainer.cpp
+++ b/src/models/ImageSectionDataContainer.cpp
@@ -357,6 +357,32 @@ QSharedPointer<AbstractListItem> ImageSectionDataContainer::getItemByLinearIndex
     return retitem;
 }
 
+
+/* Return the index of a given item (item). The 2D data list are handled like a 1D list. */
+int ImageSectionDataContainer::getLinearIndexOfItem(QFileInfo info) const
+{
+    int itmidx = 0;
+
+    std::lock_guard<std::recursive_mutex> l(d->m);
+
+    if (this->d->data.empty())
+    {
+        return -1;
+    }
+
+    for (SectionList::const_iterator sit = this->d->data.begin(); sit != this->d->data.end(); ++sit)
+    {
+        itmidx++;
+
+        if ((*sit)->find(info, &itmidx))
+        {
+            return itmidx;
+        }
+    }
+
+    return -1;
+}
+
 /* Return the index of a given item (item). The 2D data list are handled like a 1D list. */ 
 int ImageSectionDataContainer::getLinearIndexOfItem(const AbstractListItem* item) const
 {
@@ -580,6 +606,19 @@ QSharedPointer<Image> ImageSectionDataContainer::goTo(const ViewFlags_t& viewFla
     std::lock_guard<std::recursive_mutex> l(d->m);
 
     auto idx = this->getLinearIndexOfItem(img);
+    return this->goTo(viewFlags, idx, stepsFromCurrent);
+}
+
+QSharedPointer<Image> ImageSectionDataContainer::goTo(const ViewFlags_t& viewFlags, QFileInfo info, int stepsFromCurrent) const
+{
+    std::lock_guard<std::recursive_mutex> l(d->m);
+
+    auto idx = this->getLinearIndexOfItem(info);
+    return this->goTo(viewFlags, idx, stepsFromCurrent);
+}
+
+QSharedPointer<Image> ImageSectionDataContainer::goTo(const ViewFlags_t & viewFlags, int idx, int stepsFromCurrent) const
+{
     if (idx < 0)
     {
         qWarning() << "ImageSectionDataContainer::goTo(): requested image not found";

--- a/src/models/ImageSectionDataContainer.hpp
+++ b/src/models/ImageSectionDataContainer.hpp
@@ -57,7 +57,10 @@ public:
     
     QSharedPointer<AbstractListItem> getItemByLinearIndex(int idx) const;
     int getLinearIndexOfItem(const AbstractListItem* item) const;
+    int getLinearIndexOfItem(QFileInfo info) const;
     QSharedPointer<Image> goTo(const ViewFlags_t& viewFlags, const Image* img, int stepsFromCurrent) const;
+    QSharedPointer<Image> goTo(const ViewFlags_t& viewFlags, QFileInfo info, int stepsFromCurrent) const;
+    QSharedPointer<Image> goTo(const ViewFlags_t& viewFlags, int idx, int stepsFromCurrent) const;
     int size() const;
     void clear();
 

--- a/src/models/ImageSectionDataContainer.hpp
+++ b/src/models/ImageSectionDataContainer.hpp
@@ -50,6 +50,8 @@ public:
 
     ImageSectionDataContainer(SortedImageModel* model);
     ~ImageSectionDataContainer();
+    
+    void setDecodingState(DecodingState state);
 
     bool addImageItem(const QFileInfo& info);
     void addImageItem(const QVariant& section, QSharedPointer<Image>& item);

--- a/src/models/SectionItem.cpp
+++ b/src/models/SectionItem.cpp
@@ -374,6 +374,19 @@ bool SectionItem::find(const AbstractListItem* item, int* externalIdx)
     return it != this->d->data.end();
 }
 
+bool SectionItem::find(QFileInfo item, int* externalIdx)
+{
+    auto it = std::find_if(this->d->data.begin(), this->d->data.end(),
+        [=](const QSharedPointer<Image>& entry)
+        {
+            return entry.data()->fileInfo() == item;
+        });
+
+    *externalIdx += std::distance(this->d->data.begin(), it);
+    return it != this->d->data.end();
+}
+
+
 int SectionItem::find(const QFileInfo info, ImageList::iterator* itout)
 {
     auto it = std::find_if(this->d->data.begin(), this->d->data.end(),

--- a/src/models/SectionItem.hpp
+++ b/src/models/SectionItem.hpp
@@ -34,6 +34,7 @@ public:
     ImageList::iterator begin();
     bool isEnd(const SectionItem::ImageList::iterator& it) const;
     bool find(const AbstractListItem* item, int* externalIdx);
+    bool find(QFileInfo item, int* externalIdx);
     int find(const QFileInfo info, ImageList::iterator* itout);
     void insert(ImageList::iterator it, QSharedPointer<Image>& img);
     void erase(ImageList::iterator it);

--- a/src/models/SortedImageModel.cpp
+++ b/src/models/SortedImageModel.cpp
@@ -79,7 +79,7 @@ struct SortedImageModel::Impl
         auto size = q->rowCount();
         for (int i = 0; i < size; i++)
         {
-            auto img = q->imageFromItem(q->item(q->index(i,0)));
+            auto img = AbstractListItem::imageCast(q->item(q->index(i,0)));
             if (!img)
             {
                 continue;
@@ -100,7 +100,7 @@ struct SortedImageModel::Impl
         // it should be fine to wait while holding the lock
         for (int i = 0; i < size; i++)
         {
-            auto img = q->imageFromItem(q->item(q->index(i, 0)));
+            auto img = AbstractListItem::imageCast(q->item(q->index(i, 0)));
             if (!img)
             {
                 continue;
@@ -326,7 +326,7 @@ Qt::ItemFlags SortedImageModel::flags(const QSharedPointer<AbstractListItem>& it
         ViewFlags_t viewFlagsLocal = d->cachedViewFlags;
         if ((viewFlagsLocal & static_cast<ViewFlags_t>(ViewFlag::CombineRawJpg)) != 0)
         {
-            QSharedPointer<Image> e = this->imageFromItem(item);
+            QSharedPointer<Image> e = AbstractListItem::imageCast(item);
             if (e && e->hideIfNonRawAvailable(viewFlagsLocal))
             {
                 f &= ~(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
@@ -396,7 +396,7 @@ QVariant SortedImageModel::data(const QSharedPointer<AbstractListItem>& item, in
         }
         else
         {
-            auto img = this->imageFromItem(item);
+            auto img = AbstractListItem::imageCast(item);
             if (img != nullptr)
             {
                 const QFileInfo fi = img->fileInfo();
@@ -543,7 +543,7 @@ bool SortedImageModel::removeRows(int row, int count, const QModelIndex& parent)
         for(auto it = first; it != last; ++it)
         {
             // first, go through all the images, take unstarted ones from the threadpool and cancel all the other ones
-            auto img = this->imageFromItem(*it);
+            auto img = AbstractListItem::imageCast(*it);
             if (!img)
             {
                 continue;
@@ -562,7 +562,7 @@ bool SortedImageModel::removeRows(int row, int count, const QModelIndex& parent)
             // now, walk through the list again and wait for the decoders to actually finish
             // do not delete all backgroundTasks as it may already contain tasks for images from a new directory
             // it should be fine to wait while holding the lock
-            auto img = this->imageFromItem(*it);
+            auto img = AbstractListItem::imageCast(*it);
             if (!img)
             {
                 continue;
@@ -633,16 +633,6 @@ QSharedPointer<AbstractListItem> SortedImageModel::item(const QModelIndex& idx) 
     return *it;
 }
 
-QSharedPointer<Image> SortedImageModel::imageFromItem(const QSharedPointer<AbstractListItem>& item) const
-{
-    if (item != nullptr && item->getType() == ListItemType::Image)
-    {
-        return qSharedPointerDynamicCast<Image>(item);
-    }
-
-    return nullptr;
-}
-
 QList<Image*> SortedImageModel::checkedEntries()
 {
     xThreadGuard(this);
@@ -681,7 +671,7 @@ void SortedImageModel::welcomeImage(const QSharedPointer<Image>& image, const QS
                 else
                 {
                     // retrieve the QSharedPointer for *i
-                    // auto qimg = this->imageFromItem(this->item(this->index(i)));
+                    // auto qimg = AbstractListItem::imageCast(this->item(this->index(i)));
                     d->checkedImages.append(i);
                 }
             }

--- a/src/models/SortedImageModel.hpp
+++ b/src/models/SortedImageModel.hpp
@@ -56,7 +56,6 @@ public:
     QModelIndex index(const QSharedPointer<Image>& img);
     QModelIndex index(const Image* img);
     QSharedPointer<AbstractListItem> item(const QModelIndex& idx) const;
-    QSharedPointer<Image> imageFromItem(const QSharedPointer<AbstractListItem>& item) const;
     QList<Image*> checkedEntries();
 
     QVariant data(const QSharedPointer<AbstractListItem>& item, int role) const;

--- a/src/widgets/MainWindow.cpp
+++ b/src/widgets/MainWindow.cpp
@@ -568,7 +568,7 @@ struct MainWindow::Impl
         QModelIndexList idx = r.indexes();
         for(const QModelIndex& i : idx)
         {
-            auto img = model->imageFromItem(model->item(i));
+            auto img = AbstractListItem::imageCast(model->item(i));
             if (img)
             {
                 size += img->fileInfo().size();

--- a/src/widgets/MultiDocumentView.cpp
+++ b/src/widgets/MultiDocumentView.cpp
@@ -119,14 +119,14 @@ MultiDocumentView::MultiDocumentView(QMainWindow *parent)
 
 MultiDocumentView::~MultiDocumentView() = default;
 
-void MultiDocumentView::addImages(const QList<QSharedPointer<Image>>& image, QPointer<SortedImageModel> model)
+void MultiDocumentView::addImages(const QList<std::pair<QSharedPointer<Image>, QSharedPointer<ImageSectionDataContainer>>>& imageWithModel)
 {
-    if(image.empty())
+    if(imageWithModel.empty())
     {
         return;
     }
     
-    for(auto& e : image)
+    for(auto& [e, model] : imageWithModel)
     {
         DocumentView* dv = new DocumentView(this);
 
@@ -147,7 +147,7 @@ void MultiDocumentView::addImages(const QList<QSharedPointer<Image>>& image, QPo
         });
 
         d->tw->addTab(dv, "");
-        dv->setModel(model->dataContainer());
+        dv->setModel(model);
         dv->loadImage(e);
         dv->setAttribute(Qt::WA_DeleteOnClose);
     }

--- a/src/widgets/MultiDocumentView.hpp
+++ b/src/widgets/MultiDocumentView.hpp
@@ -8,7 +8,7 @@
 
 class Image;
 class QWidget;
-class SortedImageModel;
+class ImageSectionDataContainer;
 
 class MultiDocumentView : public QMainWindow
 {
@@ -18,7 +18,7 @@ public:
     MultiDocumentView(QMainWindow *parent);
     ~MultiDocumentView() override;
 
-    void addImages(const QList<QSharedPointer<Image>>& image, QPointer<SortedImageModel> model);
+    void addImages(const QList<std::pair<QSharedPointer<Image>, QSharedPointer<ImageSectionDataContainer>>>& imageWithModel);
     void keyPressEvent(QKeyEvent *event) override;
     void closeEvent(QCloseEvent *event) override;
 

--- a/src/widgets/ThumbnailListView.cpp
+++ b/src/widgets/ThumbnailListView.cpp
@@ -146,7 +146,12 @@ struct ThumbnailListView::Impl
         }
         else
         {
-            ANPV::globalInstance()->openImages(imgs);
+            QList<std::pair<QSharedPointer<Image>, QSharedPointer<ImageSectionDataContainer>>> imgsWithModel;
+            for (const auto& i : imgs)
+            {
+                imgsWithModel.push_back({ i, ANPV::globalInstance()->fileModel()->dataContainer() });
+            }
+            ANPV::globalInstance()->openImages(imgsWithModel);
         }
     }
     
@@ -461,7 +466,7 @@ QList<QSharedPointer<Image>> ThumbnailListView::selectedImages(const QModelIndex
     auto& proxyModel = dynamic_cast<QSortFilterProxyModel&>(*this->model());
     for(int i=0; i<selectedIdx.size(); i++)
     {
-        auto img = sourceModel->imageFromItem(sourceModel->item(proxyModel.mapToSource(selectedIdx[i])));
+        auto img = AbstractListItem::imageCast(sourceModel->item(proxyModel.mapToSource(selectedIdx[i])));
         if (img != nullptr)
         {
             entries.push_back(img);


### PR DESCRIPTION
ANPV supports two modes when starting up. It either opens an entire directory with the ThumbnailView. Or it opens distinct images with the DocumentView. Previously, it wasn't possible to immediately start browsing images through the DocumentView (i.e. by pressing arrow keys). One first had to open the ThumbnailView and then go back.

This has been resolved now. We first populate an ImageSectionDataContainer, extract the desired images from it, and open them in a DocumentView. The ImageSectionDataContainer is passed on to the DocumentView as well, allowing initial browsing with FileName sorting.