### PR TITLE
Fix kdcraw being unable to open some RAW files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,8 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
 endif()
 
 
+set(LIBRAW_MIN_VERSION  "0.18")
+
 find_package(PkgConfig REQUIRED)
 include(GNUInstallDirs)
 
@@ -88,6 +90,8 @@ if ( OpenMP_FOUND OR OpenMP_C_FOUND )
 endif()
 
 find_package(Qt6 COMPONENTS Core Widgets Gui Svg Test REQUIRED)
+
+find_package(LibRaw ${LIBRAW_MIN_VERSION} REQUIRED)
 
 find_package(JPEG REQUIRED)
 # required is libjpeg-tubo 2.1.4 because of https://github.com/libjpeg-turbo/libjpeg-turbo/issues/611
@@ -151,6 +155,8 @@ src/decoders/SmartTiffDecoder.cpp
 src/decoders/SmartTiffDecoder.hpp
 src/decoders/SmartJxlDecoder.cpp
 src/decoders/SmartJxlDecoder.hpp
+src/decoders/LibRawHelper.cpp
+src/decoders/LibRawHelper.hpp
 src/logic/ExifWrapper.cpp
 src/logic/ExifWrapper.hpp
 src/logic/Formatter.hpp
@@ -194,7 +200,7 @@ icons/oxygen/oxygen.qrc)
 
 
 target_compile_definitions(anpv-lib PRIVATE ANPV_VERSION="${PROJECT_VERSION}")
-target_link_libraries(anpv-lib PRIVATE Qt6::Core Qt6::Widgets Qt6::Svg PNG::PNG JPEG::JPEG TIFF::TIFF JXL::libjxl JXL::threads KExiv2 KDcraw)
+target_link_libraries(anpv-lib PRIVATE Qt6::Core Qt6::Widgets Qt6::Svg LibRaw::LibRaw PNG::PNG JPEG::JPEG TIFF::TIFF JXL::libjxl JXL::threads KExiv2 KDcraw)
 target_include_directories(anpv-lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/src/widgets ${CMAKE_CURRENT_SOURCE_DIR}/src/logic ${CMAKE_CURRENT_SOURCE_DIR}/src/decoders ${CMAKE_CURRENT_SOURCE_DIR}/src/models ${CMAKE_CURRENT_SOURCE_DIR}/src/styles)
 
 qt_add_executable(anpv MANUAL_FINALIZATION "main.cpp" "images/ANPV.rc")

--- a/cmake/FindLibRaw.cmake
+++ b/cmake/FindLibRaw.cmake
@@ -1,0 +1,87 @@
+# - Find LibRaw
+# Find the LibRaw library <https://www.libraw.org>
+# This module defines
+#  LibRaw_VERSION, the version string of LibRaw
+#  LibRaw_INCLUDE_DIR, where to find libraw.h
+#  LibRaw_LIBRARIES, the libraries needed to use LibRaw (non-thread-safe)
+#  LibRaw_r_LIBRARIES, the libraries needed to use LibRaw (thread-safe)
+#  LibRaw_DEFINITIONS, the definitions needed to use LibRaw (non-thread-safe)
+#  LibRaw_r_DEFINITIONS, the definitions needed to use LibRaw (thread-safe)
+#
+# SPDX-FileCopyrightText: 2013 Pino Toscano <pino at kde dot org>
+# SPDX-FileCopyrightText: 2013 Gilles Caulier <caulier dot gilles at gmail dot com>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+FIND_PACKAGE(PkgConfig)
+
+IF(PKG_CONFIG_FOUND)
+   PKG_CHECK_MODULES(PC_LIBRAW libraw)
+   SET(LibRaw_DEFINITIONS ${PC_LIBRAW_CFLAGS_OTHER})
+
+   PKG_CHECK_MODULES(PC_LIBRAW_R libraw_r)
+   SET(LibRaw_r_DEFINITIONS ${PC_LIBRAW_R_CFLAGS_OTHER})   
+ENDIF()
+
+FIND_PATH(LibRaw_INCLUDE_DIR libraw.h
+          HINTS
+          ${PC_LIBRAW_INCLUDEDIR}
+          ${PC_LibRaw_INCLUDE_DIRS}
+          PATH_SUFFIXES libraw
+         )
+
+FIND_LIBRARY(LibRaw_LIBRARIES NAMES raw
+             HINTS
+             ${PC_LIBRAW_LIBDIR}
+             ${PC_LIBRAW_LIBRARY_DIRS}
+            )
+
+FIND_LIBRARY(LibRaw_r_LIBRARIES NAMES raw_r
+             HINTS
+             ${PC_LIBRAW_R_LIBDIR}
+             ${PC_LIBRAW_R_LIBRARY_DIRS}
+            )
+
+IF(LibRaw_INCLUDE_DIR)
+   FILE(READ ${LibRaw_INCLUDE_DIR}/libraw_version.h _libraw_version_content)
+   
+   STRING(REGEX MATCH "#define LIBRAW_MAJOR_VERSION[ \t]*([0-9]*)\n" _version_major_match ${_libraw_version_content})
+   SET(_libraw_version_major "${CMAKE_MATCH_1}")
+   
+   STRING(REGEX MATCH "#define LIBRAW_MINOR_VERSION[ \t]*([0-9]*)\n" _version_minor_match ${_libraw_version_content})
+   SET(_libraw_version_minor "${CMAKE_MATCH_1}")
+   
+   STRING(REGEX MATCH "#define LIBRAW_PATCH_VERSION[ \t]*([0-9]*)\n" _version_patch_match ${_libraw_version_content})
+   SET(_libraw_version_patch "${CMAKE_MATCH_1}")
+   
+   IF(_version_major_match AND _version_minor_match AND _version_patch_match)
+      SET(LibRaw_VERSION "${_libraw_version_major}.${_libraw_version_minor}.${_libraw_version_patch}")
+   ELSE()
+      IF(NOT LibRaw_FIND_QUIETLY)
+         MESSAGE(STATUS "Failed to get version information from ${LibRaw_INCLUDE_DIR}/libraw_version.h")
+      ENDIF()
+   ENDIF()
+ENDIF()
+
+INCLUDE(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(LibRaw
+                                  REQUIRED_VARS LibRaw_LIBRARIES LibRaw_INCLUDE_DIR
+                                  VERSION_VAR LibRaw_VERSION
+                                 )
+
+MARK_AS_ADVANCED(LibRaw_VERSION
+                 LibRaw_INCLUDE_DIR
+                 LibRaw_LIBRARIES
+                 LibRaw_r_LIBRARIES
+                 LibRaw_DEFINITIONS
+                 LibRaw_r_DEFINITIONS
+                 )
+
+if(LibRaw_FOUND AND NOT TARGET LibRaw::LibRaw)
+    add_library(LibRaw::LibRaw UNKNOWN IMPORTED)
+    set_target_properties(LibRaw::LibRaw PROPERTIES
+        IMPORTED_LOCATION "${LibRaw_LIBRARIES}"
+        INTERFACE_COMPILE_OPTIONS "${LibRaw_DEFINITIONS}"
+        INTERFACE_INCLUDE_DIRECTORIES "${LibRaw_INCLUDE_DIR}"
+    )
+endif()

--- a/src/decoders/LibRawHelper.cpp
+++ b/src/decoders/LibRawHelper.cpp
@@ -1,0 +1,60 @@
+
+#include "LibRawHelper.hpp"
+
+#include "Formatter.hpp"
+
+// libraw basically include the entire Windoof API, messing up any C++ source code that uses std::min
+#include <libraw.h>
+#include <libraw_version.h>
+
+#ifdef LIBRAW_HAS_CONFIG
+#include <libraw_config.h>
+#endif
+
+
+void LibRawHelper::extractThumbnail(QByteArray& encodedThumbnailOut, const void* fileBuf, qint64 buflen)
+{
+	LibRaw raw;
+            
+	int ret = raw.open_buffer(const_cast<void*>(fileBuf), buflen);
+	if (ret != LIBRAW_SUCCESS)
+	{
+		throw std::runtime_error(Formatter () << "LibRaw: failed to run open_buffer: " << libraw_strerror(ret));
+	}
+
+	auto loadEmbeddedPreview = [](QByteArray& imgData, LibRaw& raw)
+	{
+		int ret = raw.unpack_thumb();
+
+		if (ret != LIBRAW_SUCCESS)
+		{
+			throw std::runtime_error(Formatter() << "LibRaw: failed to run unpack_thumb: " << libraw_strerror(ret));
+		}
+
+		libraw_processed_image_t* const thumb = raw.dcraw_make_mem_thumb(&ret);
+		if (!thumb)
+		{
+			throw std::runtime_error(Formatter() << "LibRaw: failed to run dcraw_make_mem_thumb: " << libraw_strerror(ret));
+		}
+
+		if (thumb->type == LIBRAW_IMAGE_JPEG)
+		{
+			imgData = QByteArray((const char*)thumb->data, (int)thumb->data_size);
+		}
+		else
+		{
+			raw.dcraw_clear_mem(thumb);
+			throw std::runtime_error("LibRaw returned a non-JPEG thumbnail, which is currently not supported, sry.");
+		}
+
+		raw.dcraw_clear_mem(thumb);
+		raw.recycle();
+
+		if (imgData.isEmpty())
+		{
+			throw std::runtime_error(Formatter() << "JPEG thumb from LibRaw is empty!");
+		}
+	};
+
+	loadEmbeddedPreview(encodedThumbnailOut, raw);
+}

--- a/src/decoders/LibRawHelper.hpp
+++ b/src/decoders/LibRawHelper.hpp
@@ -1,0 +1,12 @@
+
+#pragma once
+
+#include <QByteArray>
+
+class LibRawHelper
+{
+public:
+    LibRawHelper() = delete;
+	
+    static void extractThumbnail(QByteArray& encodedThumbnailOut, const void* fileBuf, qint64 buflen);
+};

--- a/src/decoders/SmartImageDecoder.cpp
+++ b/src/decoders/SmartImageDecoder.cpp
@@ -7,8 +7,8 @@
 #include "xThreadGuard.hpp"
 #include "Image.hpp"
 #include "ANPV.hpp"
+#include "LibRawHelper.hpp"
 
-#include <KDCRAW/KDcraw>
 #include <QtDebug>
 #include <QPromise>
 #include <QThreadPool>
@@ -206,21 +206,7 @@ void SmartImageDecoder::init()
         }
         else
         {
-            QString filePath = this->image()->fileInfo().absoluteFilePath();
-
-            // use KDcraw for getting the embedded preview
-            bool ret = KDcrawIface::KDcraw::loadEmbeddedPreview(d->encodedInputFile, filePath);
-
-            if(!ret)
-            {
-                // if the embedded preview loading failed, load half preview instead.
-                // That's slower but it works even for images containing
-                // small (160x120px) or none embedded preview.
-                if(!KDcrawIface::KDcraw::loadHalfPreview(d->encodedInputFile, filePath))
-                {
-                    throw std::runtime_error(Formatter() << "KDcraw failed to open RAW file '" << d->file->fileName().toStdString() << "'");
-                }
-            }
+            LibRawHelper::extractThumbnail(d->encodedInputFile, fileMapped, mapSize);
 
             d->encodedInputBufferPtr = reinterpret_cast<const unsigned char *>(d->encodedInputFile.constData());
             d->encodedInputBufferSize = d->encodedInputFile.size();


### PR DESCRIPTION
kdcraw might be unable to open a RAW file if it is located in a folder that has special characters. Might be an encoding issue somewhere. Only Release builds on Windows were affected. Get rid of all that filepath conversion stuff and use LibRaw directly to open the existing file buffer.