### PR TITLE
Revise logic for images "currently being decoded"

### DIFF
--- a/src/models/SortedImageModel.hpp
+++ b/src/models/SortedImageModel.hpp
@@ -42,6 +42,7 @@ public:
         ItemImageFocalLength,
         ItemImageLens,
         ItemImageCameraModel,
+        ItemBackgroundTask,
     };
 
     SortedImageModel(QObject *parent = nullptr);
@@ -57,6 +58,7 @@ public:
     QModelIndex index(const Image *img);
     QModelIndex index(int row, int column, const QModelIndex& parent = QModelIndex()) const override;
     QSharedPointer<AbstractListItem> item(const QModelIndex &idx) const;
+
     QList<Image *> checkedEntries();
 
     QVariant data(const QSharedPointer<AbstractListItem> &item, int role) const;
@@ -82,6 +84,10 @@ public: // QAbstractItemModel
 
 public slots:
     void cancelAllBackgroundTasks();
+
+signals:
+    void backgroundProcessingStarted();
+    void backgroundProcessingStopped();
 
 private:
     struct Impl;

--- a/src/styles/ListItemDelegate.cpp
+++ b/src/styles/ListItemDelegate.cpp
@@ -5,8 +5,12 @@
 
 #include "ListItemDelegate.hpp"
 
+#include <QFutureWatcher>
+
 #include "types.hpp"
 #include "SortedImageModel.hpp"
+#include "ANPV.hpp"
+#include "ProgressIndicatorHelper.hpp"
 
 /* Constructs a ItemDelegate object. */
 ListItemDelegate::ListItemDelegate(QObject *parent)
@@ -23,8 +27,9 @@ void ListItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &opti
     {
         return;
     }
+    auto* model = index.model();
 
-    issection = index.model()->data(index, SortedImageModel::ItemIsSection).toBool();
+    issection = model->data(index, SortedImageModel::ItemIsSection).toBool();
 
     if(issection)
     {
@@ -32,8 +37,26 @@ void ListItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &opti
     }
     else
     {
-        this->QStyledItemDelegate::paint(painter, option, index);
+        auto task = qvariant_cast<QSharedPointer<QFutureWatcher<DecodingState>>>(model->data(index, SortedImageModel::ItemBackgroundTask));
+        if (task && task->isRunning())
+        {
+            this->paintProgressIcon(painter, option, index, task.data());
+        }
+        else
+        {
+            this->QStyledItemDelegate::paint(painter, option, index);
+        }
     }
+}
+
+void ListItemDelegate::paintProgressIcon(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index, const QFutureWatcher<DecodingState>* task) const
+{
+    // transform bounds, otherwise fills the whole cell
+    auto bounds = option.rect;
+    //bounds.setWidth(28);
+    //bounds.moveTo(option.rect.center().x() - bounds.width() / 2, option.rect.center().y() - bounds.height() / 2);
+
+    ANPV::globalInstance()->spinningIconHelper()->drawProgressIndicator(painter, bounds, *task);
 }
 
 /* Paints a section item with a given model index (index) and options (option) on a painter object (painter). */

--- a/src/styles/ListItemDelegate.hpp
+++ b/src/styles/ListItemDelegate.hpp
@@ -10,6 +10,10 @@
 #include <QPixmap>
 #include <QRegularExpression>
 #include <QSize>
+#include <QFutureWatcher>
+
+#include "DecodingState.hpp"
+
 
 class ListItemDelegate : public QStyledItemDelegate
 {
@@ -23,6 +27,7 @@ public:
 
 protected:
     void paintSection(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;
+    void paintProgressIcon(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex&, const QFutureWatcher<DecodingState>* task) const;
 
 private:
     /* size of a section item */

--- a/src/widgets/ProgressIndicatorHelper.cpp
+++ b/src/widgets/ProgressIndicatorHelper.cpp
@@ -106,11 +106,14 @@ void ProgressIndicatorHelper::drawProgressIndicator(QPainter* localPainter, cons
     xThreadGuard(this);
 
     std::unique_lock<std::recursive_mutex> l(d->m);
-    localPainter->drawImage(bounds, d->currentFrame);
+    QRect icoRect = d->currentFrame.rect();
+    icoRect.moveTo(bounds.topLeft());
+    icoRect = icoRect.intersected(bounds);
+    localPainter->drawImage(icoRect, d->currentFrame);
     l.unlock();
 
     int prog = future.progressValue();
     localPainter->setPen(future.isCanceled() ? Qt::red : Qt::blue);
     localPainter->setFont(QFont("Arial", 30));
-    localPainter->drawText(bounds, Qt::AlignHCenter | Qt::AlignVCenter, QString("%1%").arg(QString::number(prog)));
+    localPainter->drawText(icoRect, Qt::AlignHCenter | Qt::AlignVCenter, QString("%1%").arg(QString::number(prog)));
 }

--- a/src/widgets/ProgressIndicatorHelper.hpp
+++ b/src/widgets/ProgressIndicatorHelper.hpp
@@ -17,7 +17,7 @@ class ProgressIndicatorHelper : public QObject
 public:
     ProgressIndicatorHelper(QObject *parent = nullptr);
     ~ProgressIndicatorHelper();
-    QPixmap getProgressIndicator(const QFutureWatcher<DecodingState> &future);
+    void drawProgressIndicator(QPainter* localPainter, const QRect& bounds, const QFutureWatcher<DecodingState> &future);
 
 public slots:
     void startRendering();

--- a/test/ProgressWidgetTest.cpp
+++ b/test/ProgressWidgetTest.cpp
@@ -72,16 +72,20 @@ int main(int argc, char **argv)
     QObject::connect(&spinner, &ProgressIndicatorHelper::needsRepaint, &spinningIcon,
                      [&]()
                      {
-                         QPixmap frame;
+                         QPixmap frame(spinningIcon.size());
+                         frame.fill();
                          QPainter painter;
+                         painter.begin(&frame);
                          spinner.drawProgressIndicator(&painter, spinningIcon.rect(), wat);
                          spinningIcon.setPixmap(frame);
                      });
     QObject::connect(&wat, &QFutureWatcher<DecodingState>::progressValueChanged, &spinner,
                      [&]()
                      {
-                         QPixmap frame;
+                         QPixmap frame(spinningIcon.size());
+                         frame.fill();
                          QPainter painter;
+                         painter.begin(&frame);
                          spinner.drawProgressIndicator(&painter, spinningIcon.rect(), wat);
                          spinningIcon.setPixmap(frame);
                      });
@@ -89,8 +93,10 @@ int main(int argc, char **argv)
     QObject::connect(&wat, &QFutureWatcher<DecodingState>::finished, &spinner, &ProgressIndicatorHelper::stopRendering);
     QObject::connect(&wat, &QFutureWatcher<DecodingState>::canceled, &spinner,
                      [&](){
-                         QPixmap frame;
+                         QPixmap frame(spinningIcon.size());
+                         frame.fill();
                          QPainter painter;
+                         painter.begin(&frame);
                          spinner.drawProgressIndicator(&painter, spinningIcon.rect(), wat);
                          spinningIcon.setPixmap(frame);
                          spinner.stopRendering(); });

--- a/test/ProgressWidgetTest.cpp
+++ b/test/ProgressWidgetTest.cpp
@@ -12,6 +12,7 @@
 #include <QDebug>
 #include <QFuture>
 #include <QPromise>
+#include <QPainter>
 #include <QMainWindow>
 #include <QApplication>
 
@@ -71,20 +72,26 @@ int main(int argc, char **argv)
     QObject::connect(&spinner, &ProgressIndicatorHelper::needsRepaint, &spinningIcon,
                      [&]()
                      {
-                         QPixmap frame = spinner.getProgressIndicator(wat);
+                         QPixmap frame;
+                         QPainter painter;
+                         spinner.drawProgressIndicator(&painter, spinningIcon.rect(), wat);
                          spinningIcon.setPixmap(frame);
                      });
     QObject::connect(&wat, &QFutureWatcher<DecodingState>::progressValueChanged, &spinner,
                      [&]()
                      {
-                         QPixmap frame = spinner.getProgressIndicator(wat);
+                         QPixmap frame;
+                         QPainter painter;
+                         spinner.drawProgressIndicator(&painter, spinningIcon.rect(), wat);
                          spinningIcon.setPixmap(frame);
                      });
     QObject::connect(&wat, &QFutureWatcher<DecodingState>::started,  &spinner, &ProgressIndicatorHelper::startRendering);
     QObject::connect(&wat, &QFutureWatcher<DecodingState>::finished, &spinner, &ProgressIndicatorHelper::stopRendering);
     QObject::connect(&wat, &QFutureWatcher<DecodingState>::canceled, &spinner,
                      [&](){
-                         QPixmap frame = spinner.getProgressIndicator(wat);
+                         QPixmap frame;
+                         QPainter painter;
+                         spinner.drawProgressIndicator(&painter, spinningIcon.rect(), wat);
                          spinningIcon.setPixmap(frame);
                          spinner.stopRendering(); });
     wat.setFuture(fut);


### PR DESCRIPTION
Instead of spamming the UI thread with a bunch of icon-changed events to get the illusion of an animated icon, the progress icon is now drawn in the ListItemDelegate, and the ThumbnailListView is invalidated regularly.